### PR TITLE
Bump to v0.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Changelog
 
+## 0.1.10
+* relaxed dependency constraints for `polars` (<2) and `requests` (<4)
+
 ## 0.1.9
-* completed schema-sync; new authoritative LCA & distance tests
-* `SQLiteTaxonomyService.distance` now defaults to `include_minor_ranks=False` and `inclusive=False`
-* sample TSV renamed to `expanded_taxa_sample.tsv`; fixture generated as `expanded_taxa_sample.sqlite`
+* NEW: `sqlite_loader` service with `typus-load-sqlite` CLI for offline databases
+* CHG: Postgres service falls back to recursive CTEs when path columns missing
+* DOC: Added MkDocs site with `offline_mode.md` and `expanded_taxa.md`
+* TEST: expanded suite covering offline loader and LCA cases
+* DEP: optional extras for PyArrow and MkDocs
 
 ## 0.1.8 – 2025-06-29
 ### Changed

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ database services. Anything that speaks taxonomy imports **Typus** and stays DRY
   multi‑scale elevation sinusoids.
 * **Optional drivers only when you need them** – install
   `polli-typus[postgres]` or `[sqlite]`; core install stays lightweight.
+* **Offline SQLite loader** – `typus-load-sqlite` CLI builds and caches the offline dataset
 
 ---
 
@@ -87,6 +88,9 @@ from typus.services import SQLiteTaxonomyService, load_expanded_taxa
 db = Path("expanded_taxa.sqlite")
 load_expanded_taxa(db)  # downloads if missing
 svc = SQLiteTaxonomyService(db)
+```
+```bash
+typus-load-sqlite --sqlite expanded_taxa.sqlite
 ```
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name            = "polli-typus"
-version         = "0.1.9"
+version         = "0.1.10"
 description     = "Taxonomic types, projections and async taxonomy services for Polli-Labs."
 readme          = { file = "README.md", content-type = "text/markdown" }
 license         = "MIT"
@@ -26,8 +26,8 @@ dependencies = [
     "pydantic>=2.7,<3",
     "sqlalchemy[asyncio]>=2.0,<3",
     "rapidfuzz>=3.6,<4",
-    "polars>=0.20,<0.21",      # NEW – core runtime needs it
-    "requests>=2.32,<3",       # NEW – used by load_expanded_taxa helper
+    "polars>=0.20,<2",      # NEW – core runtime needs it
+    "requests>=2.32,<4",       # NEW – used by load_expanded_taxa helper
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- loosen the `polars` and `requests` constraints
- bump version to `0.1.10`
- document the dependency change in the changelog
- flesh out changelog entry for `0.1.9`
- mention new SQLite loader in README

## Testing
- `ruff format .`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68646703eb90832e8c18f3e409d22575