### PR TITLE
Add docs deploy job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,3 +44,24 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: dist/*.whl
+
+  deploy-docs:
+    name: Deploy Docs to VPS
+    runs-on: ubuntu-latest
+    needs: build-and-publish
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.12' }
+      - run: |
+          python -m pip install -U pip
+          pip install mkdocs mkdocs-material
+      - run: mkdocs build
+      - uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.POLLISERVE0_SSH_PRIVATE_KEY }}
+      - run: |
+          rsync -avz --delete \
+            -e "ssh -o StrictHostKeyChecking=no" \
+            site/ ${{ secrets.POLLISERVE0_SSH_USER }}@${{ secrets.POLLISERVE0_SSH_PUBLIC_HOST }}:/var/www/docs.polli.ai/html/typus/


### PR DESCRIPTION
## Summary
- add `deploy-docs` job to workflow to publish MkDocs on tagged releases

## Testing
- `ruff format .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864b53b2148832ebc3668d74573ed05