### PR TITLE
feat: typus v0.3.0 - canonical geometry & provider mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * **NEW**: Pixel ↔ normalized coordinate conversion utilities
   - `to_xyxy_px()` and `from_xyxy_px()` functions for round-trip conversion
   - Sub-pixel accuracy (≤0.5px error) across different image dimensions
+  - Half-up rounding rule for pixel conversion (ties away from zero) ensures deterministic edge semantics
 * **NEW**: Enhanced Track models with canonical geometry support
   - `Detection` model supports both `bbox_norm` (canonical) and `bbox` (legacy) fields
   - Factory method `Detection.from_raw_detection()` with provider mapping

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## 0.3.0
+### Added - Canonical Geometry
+* **NEW**: `BBoxXYWHNorm` - Canonical top-left normalized bbox type with strict invariant validation
+  - Immutable Pydantic model enforcing `[x, y, w, h]` format with `0 ≤ x,y ≤ 1`, `0 < w,h ≤ 1`
+  - Coordinate bounds checking: `x + w ≤ 1`, `y + h ≤ 1`
+  - Non-finite value rejection (NaN, Infinity)
+* **NEW**: Provider-specific bbox mapping registry (`BBoxMapper`)
+  - Built-in support for Gemini bottom-right origin conversion (`gemini_br_xyxy` mapper)
+  - Pluggable architecture for custom coordinate system mappings
+* **NEW**: Pixel ↔ normalized coordinate conversion utilities
+  - `to_xyxy_px()` and `from_xyxy_px()` functions for round-trip conversion
+  - Sub-pixel accuracy (≤0.5px error) across different image dimensions
+* **NEW**: Enhanced Track models with canonical geometry support
+  - `Detection` model supports both `bbox_norm` (canonical) and `bbox` (legacy) fields
+  - Factory method `Detection.from_raw_detection()` with provider mapping
+  - Updated examples and validation to use canonical format
+* **NEW**: JSON Schemas for canonical geometry types
+  - Auto-generated schemas for `BBoxXYWHNorm`, `Detection`, `Track`, `TrackStats`
+  - Available in `typus/schemas/` directory for API documentation
+* **NEW**: Comprehensive documentation for canonical geometry
+  - New `docs/geometry.md` with usage examples and migration guide
+  - Updated `docs/models.md` to highlight canonical types over legacy formats
+  - Updated `docs/tracks.md` with canonical bbox examples and provider mapping
+
+### Changed
+* **API**: Detection model now requires either `bbox_norm` or `bbox` field (validation enforced)
+* **EXPORT**: Added canonical geometry types to public API exports
+  - `from typus import BBoxXYWHNorm, BBoxMapper, to_xyxy_px, from_xyxy_px`
+* **DOCS**: Legacy geometry types demoted to "Legacy" section with deprecation notices
+* **EXAMPLES**: All documentation examples updated to use canonical format
+
+### Backwards Compatibility
+* **MAINTAINED**: All existing `bbox` (pixel) fields continue to work
+* **MAINTAINED**: Existing `BBox` and geometry enums unchanged
+* **MAINTAINED**: No breaking changes to public APIs
+
 ## 0.2.1
 ### Added
 * **NEW**: Track models for video object tracking (`Detection`, `Track`, `TrackStats`)

--- a/dev/issues/BBOX-CANONICAL-0001.md
+++ b/dev/issues/BBOX-CANONICAL-0001.md
@@ -1,0 +1,127 @@
+**Superseded by:** `TYPUS-GEOM-0001`, `TYPUS-MODELS-0002`, `TYPUS-SCHEMA-0003`, `TYPUS-DOC-0004`, `TYPUS-REL-0005`.
+**Rationale:** Split work into canonical type + mappers, models alignment, schemas, and docs; release tracked in `TYPUS-REL-0005`.
+
+# BBOX-CANONICAL-0001: Update Track models to align with ibrida v0.6.3 canonical bbox format
+
+## Issue Classification
+- **Priority**: P1 (API contract alignment)
+- **Component**: typus.models.tracks  
+- **Filed**: 2025-08-29
+- **Milestone**: typus v0.2.x (next release)
+
+## Problem Statement
+
+The typus Track models currently accept bbox coordinates in generic `list[float]` format without specifying the coordinate system contract. With ibrida v0.6.3's bbox geometry overhaul standardizing on **canonical format**, typus should align its models and documentation to prevent integration issues.
+
+## Current Implementation
+
+In `typus/models/tracks.py`, the Detection model defines:
+
+```python
+bbox: list[float] = Field(
+    ..., min_length=4, max_length=4, description="Bounding box [x, y, width, height] in pixels"
+)
+```
+
+This generic description doesn't specify:
+- Coordinate origin (top-left vs bottom-right)
+- Normalization (pixel vs normalized [0,1])
+- Coordinate order (xywh vs xyxy)
+
+## Target Canonical Format
+
+Based on ibrida v0.6.3 implementation:
+- **Format**: `[x, y, width, height]`
+- **Origin**: Top-left corner
+- **Coordinates**: Normalized float values in `[0, 1]` range
+- **Validation**: `0 ≤ x ≤ 1`, `0 ≤ y ≤ 1`, `0 < w ≤ 1`, `0 < h ≤ 1`, `x+w ≤ 1`, `y+h ≤ 1`
+
+## Required Changes
+
+### 1. Update Field Documentation
+
+```python
+bbox: list[float] = Field(
+    ..., 
+    min_length=4, 
+    max_length=4, 
+    description="Canonical bounding box [x, y, width, height] - top-left origin, normalized [0,1]"
+)
+```
+
+### 2. Add Validation (Optional)
+
+Consider adding a Pydantic validator to ensure canonical compliance:
+
+```python
+@field_validator('bbox')
+def validate_canonical_bbox(cls, v):
+    if len(v) != 4:
+        raise ValueError('bbox must have exactly 4 elements')
+    
+    x, y, w, h = v
+    if not (0 <= x <= 1 and 0 <= y <= 1):
+        raise ValueError('bbox x,y must be in [0,1] range')
+    if not (0 < w <= 1 and 0 < h <= 1):
+        raise ValueError('bbox width,height must be in (0,1] range')
+    if x + w > 1.001 or y + h > 1.001:  # Allow small epsilon
+        raise ValueError('bbox must not exceed frame boundaries')
+        
+    return v
+```
+
+### 3. Update Documentation
+
+Update `docs/tracks.md` examples to use canonical format:
+
+```python
+detection = Detection(
+    frame_number=100,
+    bbox=[0.1, 0.2, 0.5, 0.6],  # Canonical: top-left normalized xywh
+    confidence=0.95,
+    taxon_id=47219,
+    scientific_name="Apis mellifera"
+)
+```
+
+### 4. Migration Guidance
+
+Add adapter function for legacy pixel formats:
+
+```python
+def pixel_to_canonical_bbox(pixel_bbox: list[float], img_width: int, img_height: int) -> list[float]:
+    """Convert pixel bbox to canonical normalized format."""
+    x_px, y_px, w_px, h_px = pixel_bbox
+    return [
+        x_px / img_width,
+        y_px / img_height,
+        w_px / img_width,
+        h_px / img_height
+    ]
+```
+
+## API Compatibility Impact
+
+- **Breaking Change**: No (current validation accepts any 4-element float list)
+- **Behavioral Change**: Yes (documentation clarifies expected format)
+- **Migration Path**: Existing pixel-space data needs conversion
+
+## Integration Benefits
+
+1. **Consistent Contract**: Matches ibrida v0.6.3 canonical format
+2. **Better Validation**: Prevents coordinate system mix-ups
+3. **Clearer Documentation**: Removes ambiguity for API consumers
+4. **Future-Proofing**: Aligns with ecosystem bbox format standards
+
+## Implementation Notes
+
+- Coordinate with ibrida team on final canonical format specification
+- Consider backward compatibility for existing typus data
+- Update JSON schema exports to reflect canonical format
+- Add unit tests for bbox validation edge cases
+
+## Cross-Reference
+
+- **Source**: ibrida v0.6.3 bbox geometry overhaul (PR #20)
+- **Related**: ibrida BBOX-ORIGIN-0001, BBOX-OVERLAY-0004
+- **Spec**: `ibrida/src/ibrida/distill/response_validation.py` canonical format implementation

--- a/dev/issues/P0/TYPUS-GEOM-0001.md
+++ b/dev/issues/P0/TYPUS-GEOM-0001.md
@@ -1,0 +1,59 @@
+---
+id: TYPUS-GEOM-0001
+title: Canonical bbox types + provider mapping registry
+status: open
+priority: P0
+component: geometry
+milestone: v0.3.0
+labels: [schema, geometry, canonical, non-breaking]
+owner: typus-agent
+created: 2025-08-29
+blocks: [TYPUS-MODELS-0002, TYPUS-SCHEMA-0003, TYPUS-DOC-0004]
+---
+
+**Motivation**
+`typus` must be the **single canonical package** for geometry contracts across org repos. We will introduce an immutable, strictly‑validated **canonical bbox** type (TL‑origin, normalized `[x, y, w, h]`) and a tiny registry for **provider‑specific mappings** (initially: Gemini BR/xyxy → canonical). Current docs and examples still show ad‑hoc "list[float]" bboxes and multiple formats; we need a contract lock‑in here. 
+
+**Scope (deliverables)**
+
+1. **Type: `BBoxXYWHNorm` (Pydantic, frozen)**
+
+   * Fields: `x: float`, `y: float`, `w: float`, `h: float`
+   * Invariants: `0 ≤ x ≤ 1`, `0 ≤ y ≤ 1`, `0 < w ≤ 1`, `0 < h ≤ 1`, `x + w ≤ 1 + 1e-9`, `y + h ≤ 1 + 1e-9`
+   * `model_config = ConfigDict(frozen=True)` for immutability.
+
+2. **Converters (pure functions)**
+
+   * `to_xyxy_px(b: BBoxXYWHNorm, W: int, H: int) -> tuple[int, int, int, int]`
+   * `from_xyxy_px(x1: float, y1: float, x2: float, y2: float, W: int, H: int) -> BBoxXYWHNorm`
+     (Clamp with ε=1e‑9; assert `x2 ≥ x1`, `y2 ≥ y1` pre‑normalize.)
+
+3. **Provider mapping registry**
+
+   * `class BBoxMapper:` `register(name: str, fn: Callable)`, `get(name: str) -> Callable`
+   * Provide entry: `"gemini_br_xyxy"` → function that takes Gemini **bottom‑right–origin** xyxy + `(upload_w, upload_h)` and returns canonical `BBoxXYWHNorm`. (Document the BR→TL math in code docstrings.)
+
+4. **Inferences (optional, guard‑railed)**
+
+   * `infer_from_raw(raw: Sequence[float] | dict, upload_w: int, upload_h: int, *, prefer="tl_xywh_norm") -> BBoxXYWHNorm`
+     with explicit failure unless a provider hint or unambiguous normalized TL‑xywh is detected. (No silent magic.)
+
+5. **Public API exports**
+
+   * Re‑export in `typus/models/__init__.py`: `BBoxXYWHNorm`, `BBoxMapper`, and the converter functions.
+     Current exports only include `BBox`, `EncodedMask`, `InstancePrediction`, `ImageDetectionResult`; add the new canonical pieces next to them. 
+
+**Tests**
+
+* `tests/test_geometry_bbox_norm.py`: validators, boundary cases (`x+w==1`, `w==1`).
+* `tests/test_geometry_px_roundtrip.py`: pix ↔ norm round‑trip within 0.5px.
+* `tests/test_provider_gemini_mapping.py`: golden vectors for BR/xyxy → TL/xywh on representative dims.
+
+**Acceptance**
+
+* All new tests pass; no mutation of `BBoxXYWHNorm` after construction.
+* Public imports: `from typus import BBoxXYWHNorm` succeed.
+* Mappers are pluggable via `BBoxMapper.register(...)`.
+
+**Notes**
+This is **additive**; no existing import paths break. Follow repo's dev workflow & test tooling (`pytest`, `ruff`, `pre‑commit`). 

--- a/dev/issues/P0/TYPUS-MODELS-0002.md
+++ b/dev/issues/P0/TYPUS-MODELS-0002.md
@@ -1,0 +1,41 @@
+---
+id: TYPUS-MODELS-0002
+title: Align Detection/Track models to canonical TL-normalized xywh
+status: open
+priority: P0
+component: models
+milestone: v0.3.0
+labels: [models, geometry, canonical]
+owner: typus-agent
+created: 2025-08-29
+depends_on: [TYPUS-GEOM-0001]
+blocks: [TYPUS-SCHEMA-0003, TYPUS-DOC-0004, TYPUS-REL-0005]
+---
+
+**Problem**
+`typus` docs and examples still illustrate bboxes as free‑form `list[float]` in "tracks" docs, with no coordinate contract. We need to **use the canonical type** in our public models and docs. 
+
+**Scope**
+
+1. **Models**
+
+   * In `typus/models/detection.py` and/or `typus/models/tracks.py` (if present), ensure bbox‑carrying objects reference **`BBoxXYWHNorm`** for canonical fields rather than bare `list[float]`.
+     (The codebase already has `BBox` & `EncodedMask` and exports image detection models; extend without breaking those.) 
+   * If legacy fields exist (e.g., `bbox: List[float]`), keep a **compat** field (deprecated in docstring) and add a new `bbox_norm: BBoxXYWHNorm`. Migration path: populate `bbox_norm` from adapters when constructing from legacy payloads.
+
+2. **Factory/adapters**
+
+   * Provide `from_raw_detection(raw: dict, *, upload_w: int, upload_h: int, provider: str | None = None)` helpers that produce canonicalized models using `BBoxMapper` or strict `bbox_norm` validation when already canonical.
+
+3. **Validation**
+
+   * Enforce canonical invariants at model boundaries; reject ambiguous inputs unless a `provider` is given.
+
+**Tests**
+
+* `tests/test_models_canonical_bbox.py`: constructing detections/tracks with canonical bbox; legacy path raises or adapts only with explicit provider hint.
+
+**Acceptance**
+
+* Canonical fields present and required in model constructors.
+* Legacy examples in docs removed or clearly marked.

--- a/dev/issues/P0/TYPUS-REL-0005.md
+++ b/dev/issues/P0/TYPUS-REL-0005.md
@@ -1,0 +1,23 @@
+---
+id: TYPUS-REL-0005
+title: Release typus v0.3.0 (canonical geometry)
+status: open
+priority: P0
+component: release
+milestone: v0.3.0
+labels: [release, versioning, docs]
+owner: typus-agent
+created: 2025-08-29
+depends_on: [TYPUS-GEOM-0001, TYPUS-MODELS-0002, TYPUS-SCHEMA-0003, TYPUS-DOC-0004]
+---
+
+**Work**
+
+* Bump version to `0.3.0` in packaging metadata; keep CI/publish workflow as is. 
+* Update CHANGELOG: "Added canonical geometry types & mappings; updated models/docs; schemas exported."
+* Ensure `__all__` re‑exports include `BBoxXYWHNorm` and `BBoxMapper`. 
+* Tag & publish (TestPyPI → PyPI) and deploy docs via existing GH Actions. 
+
+**Acceptance**
+
+* Wheel published; docs deployed; schemas updated.

--- a/dev/issues/P1/TYPUS-DOC-0004.md
+++ b/dev/issues/P1/TYPUS-DOC-0004.md
@@ -1,0 +1,23 @@
+---
+id: TYPUS-DOC-0004
+title: Document canonical TL-normalized xywh + provider mappings; update model docs
+status: open
+priority: P1
+component: docs
+milestone: v0.3.0
+labels: [docs, geometry, migration]
+owner: typus-agent
+created: 2025-08-29
+depends_on: [TYPUS-GEOM-0001, TYPUS-MODELS-0002]
+---
+
+**Work**
+
+* Add a new `docs/geometry.md` explaining canonical invariants & examples; link from `docs/index.md`. 
+* Update `docs/models.md` geometry section (currently lists many formats) to **highlight canonical** and demote others as non‑canonical. 
+* Update `docs/tracks.md` examples to use `BBoxXYWHNorm` and remove "list[float]" bboxes. 
+
+**Acceptance**
+
+* MkDocs build includes a **Canonical geometry** page.
+* Examples use canonical types end‑to‑end.

--- a/dev/issues/P1/TYPUS-SCHEMA-0003.md
+++ b/dev/issues/P1/TYPUS-SCHEMA-0003.md
@@ -1,0 +1,22 @@
+---
+id: TYPUS-SCHEMA-0003
+title: Export JSON Schemas for BBoxXYWHNorm and updated detection/track models
+status: open
+priority: P1
+component: schemas
+milestone: v0.3.0
+labels: [schemas, tooling]
+owner: typus-agent
+created: 2025-08-29
+depends_on: [TYPUS-GEOM-0001, TYPUS-MODELS-0002]
+---
+
+**Work**
+
+* Update `typus/export_schemas.py` `MODELS` list to include `typus.models.geometry.BBoxXYWHNorm` and any updated detection/track models; run `python -m typus.export_schemas` to emit JSON into `typus/schemas/`. 
+* Commit generated `*.json` files.
+
+**Acceptance**
+
+* `typus/schemas/BBoxXYWHNorm.json` exists and contains the invariants.
+* CI step prints `wrote BBoxXYWHNorm.json` along with the others. 

--- a/docs/geometry.md
+++ b/docs/geometry.md
@@ -1,0 +1,209 @@
+# Canonical Geometry
+
+As of `typus v0.3.0`, the library provides canonical geometry types that establish a **single source of truth** for bounding box coordinates across all Polli-Labs repositories.
+
+## Canonical Bounding Box Format
+
+The canonical format is:
+
+- **Coordinate System**: Top-left origin (0,0 at top-left corner)
+- **Format**: `[x, y, width, height]` 
+- **Normalization**: All values in `[0, 1]` range relative to image dimensions
+- **Type**: `BBoxXYWHNorm` (immutable Pydantic model)
+
+### Invariants
+
+The `BBoxXYWHNorm` type enforces these constraints:
+
+- `0 ≤ x ≤ 1` (left coordinate)
+- `0 ≤ y ≤ 1` (top coordinate)  
+- `0 < w ≤ 1` (width, must be positive)
+- `0 < h ≤ 1` (height, must be positive)
+- `x + w ≤ 1` (cannot exceed right image boundary)
+- `y + h ≤ 1` (cannot exceed bottom image boundary)
+
+## Usage Examples
+
+### Creating Canonical Bboxes
+
+```python
+from typus import BBoxXYWHNorm
+
+# Create a bbox covering 20% to 70% horizontally, 10% to 60% vertically
+bbox = BBoxXYWHNorm(x=0.2, y=0.1, w=0.5, h=0.5)
+
+# The bbox is immutable
+# bbox.x = 0.3  # This would raise TypeError
+```
+
+### Converting Between Pixel and Normalized Coordinates
+
+```python
+from typus import BBoxXYWHNorm, to_xyxy_px, from_xyxy_px
+
+# Convert from pixel coordinates to canonical
+image_width, image_height = 1920, 1080
+pixel_bbox = from_xyxy_px(x1=384, y1=108, x2=1344, y2=648, W=image_width, H=image_height)
+# Result: BBoxXYWHNorm(x=0.2, y=0.1, w=0.5, h=0.5)
+
+# Convert canonical back to pixel coordinates  
+x1, y1, x2, y2 = to_xyxy_px(pixel_bbox, W=image_width, H=image_height)
+# Result: (384, 108, 1344, 648)
+```
+
+## Provider Mapping
+
+Different vision APIs use different coordinate systems. The `BBoxMapper` registry provides conversions from provider-specific formats to canonical format.
+
+### Supported Providers
+
+#### Gemini (Bottom-Right Origin)
+
+Gemini Vision API uses bottom-right origin coordinates. Use the built-in mapper:
+
+```python
+from typus import BBoxMapper
+
+# Get the Gemini mapper
+mapper = BBoxMapper.get("gemini_br_xyxy")
+
+# Convert Gemini bottom-right xyxy to canonical
+gemini_coords = [50, 50, 80, 90]  # Bottom-right origin pixel coordinates
+image_width, image_height = 100, 100
+
+canonical_bbox = mapper(*gemini_coords, image_width, image_height)
+```
+
+#### Custom Providers
+
+Register your own provider mappings:
+
+```python
+from typus import BBoxMapper, BBoxXYWHNorm
+
+def my_provider_mapper(x1, y1, x2, y2, W, H):
+    # Custom conversion logic here
+    # Must return BBoxXYWHNorm
+    return BBoxXYWHNorm(
+        x=x1/W, y=y1/H,
+        w=(x2-x1)/W, h=(y2-y1)/H
+    )
+
+BBoxMapper.register("my_provider", my_provider_mapper)
+
+# Use it
+bbox = BBoxMapper.get("my_provider")(10, 20, 50, 60, 100, 100)
+```
+
+## Integration with Models
+
+### Detection Models
+
+The `Detection` model (used in tracks) supports both canonical and legacy bbox formats:
+
+```python
+from typus.models.tracks import Detection
+from typus import BBoxXYWHNorm
+
+# Preferred: Use canonical bbox
+detection = Detection(
+    frame_number=100,
+    bbox_norm=BBoxXYWHNorm(x=0.1, y=0.2, w=0.5, h=0.6),
+    confidence=0.95
+)
+
+# Legacy support (deprecated)
+detection_legacy = Detection(
+    frame_number=100, 
+    bbox=[10, 20, 50, 60],  # Pixel coordinates - DEPRECATED
+    confidence=0.95
+)
+```
+
+### Converting Raw Detection Data
+
+Use the factory method to convert from provider-specific formats:
+
+```python
+# Raw detection from Gemini API
+raw_detection = {
+    "frame_number": 100,
+    "bbox": [50, 50, 80, 90],  # Gemini bottom-right coordinates
+    "confidence": 0.95
+}
+
+# Convert to canonical format
+detection = Detection.from_raw_detection(
+    raw_detection,
+    upload_w=100, upload_h=100,
+    provider="gemini_br_xyxy"
+)
+
+# Now has both canonical and legacy fields
+assert detection.bbox_norm is not None  # Canonical format
+assert detection.bbox == [50, 50, 80, 90]  # Legacy preserved
+```
+
+## Migration Guide
+
+### From Pixel to Canonical
+
+If you have existing code using pixel bboxes:
+
+```python
+# Before (v0.2.x)
+bbox_pixels = [10, 20, 50, 60]  # x, y, width, height in pixels
+
+# After (v0.3.0+) 
+from typus import BBoxXYWHNorm
+image_width, image_height = 100, 100
+bbox_canonical = BBoxXYWHNorm(
+    x=10/image_width,    # 0.1
+    y=20/image_height,   # 0.2  
+    w=50/image_width,    # 0.5
+    h=60/image_height    # 0.6
+)
+```
+
+### From Multiple Formats to Canonical
+
+Replace ad-hoc format handling:
+
+```python
+# Before: Multiple format support
+def handle_bbox(bbox, format_hint):
+    if format_hint == "xyxy":
+        # Handle xyxy
+    elif format_hint == "xywh":
+        # Handle xywh
+    # ... more formats
+
+# After: Single canonical format
+def handle_bbox(bbox: BBoxXYWHNorm):
+    # Always canonical TL-normalized xywh
+    # No format ambiguity
+```
+
+## Best Practices
+
+1. **Always use canonical format** for new code
+2. **Convert at API boundaries** using provider mappers  
+3. **Store in canonical format** to avoid coordinate system bugs
+4. **Use factory methods** like `Detection.from_raw_detection()` for conversion
+5. **Validate early** - canonical types enforce invariants at construction time
+
+## JSON Schema
+
+The canonical geometry types provide JSON schemas for API documentation and validation:
+
+```python
+from typus import BBoxXYWHNorm
+
+schema = BBoxXYWHNorm.model_json_schema()
+# Use schema for OpenAPI docs, request validation, etc.
+```
+
+Generated schemas are available in `typus/schemas/` directory:
+- `BBoxXYWHNorm.json`
+- `Detection.json` 
+- `Track.json`

--- a/docs/geometry.md
+++ b/docs/geometry.md
@@ -112,6 +112,21 @@ image_width, image_height = 100, 100
 canonical_bbox = mapper(*gemini_coords, image_width, image_height)
 ```
 
+#### Provider Discovery
+
+List all available providers for introspection:
+
+```python
+from typus import BBoxMapper
+
+# Discover available providers
+providers = BBoxMapper.list_providers()
+print(providers)  # ['gemini_br_xyxy', ...]
+
+# Use a specific provider by canonical name
+mapper = BBoxMapper.get("gemini_br_xyxy")
+```
+
 #### Custom Providers
 
 Register your own provider mappings:

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,8 @@
 
 Typus provides cross‑platform taxonomic models and asynchronous services for taxonomy queries.
 
+* **[Canonical Geometry](geometry.md)** – standardized bounding box formats and provider mappings (v0.3.0+)
 * **Taxonomy Service** – see [overview](taxonomy_service.md) and [Offline mode](offline_mode.md).
+* **[Models](models.md)** – detection and geometry data structures.
+* **[Tracks](tracks.md)** – object tracking models for video analysis.
 * **expanded_taxa schema** – details of the materialised view.
-* **Models** – detection and geometry data structures.

--- a/docs/models.md
+++ b/docs/models.md
@@ -9,18 +9,52 @@ Refer to existing documentation or source code for `HierarchicalClassificationRe
 
 ## Geometry Models
 
-These models define basic geometric primitives used in detection and segmentation tasks.
+### **Canonical Geometry (v0.3.0+)**
 
-### `BBoxFormat` (Enum)
+**For new code, always use the canonical `BBoxXYWHNorm` type.** See the [Canonical Geometry](geometry.md) documentation for full details.
 
-Defines the format of a bounding box's coordinates.
+#### `BBoxXYWHNorm` (Recommended)
+
+The canonical bounding box format with enforced invariants:
+
+- **Format**: `[x, y, width, height]` (top-left origin)
+- **Normalization**: All values in `[0, 1]` range  
+- **Immutable**: Cannot be modified after creation
+- **Validated**: Enforces coordinate bounds and non-finite rejection
+
+**Example:**
+
+```python
+from typus import BBoxXYWHNorm
+
+# Canonical bbox covering 20%-70% horizontally, 10%-60% vertically
+bbox = BBoxXYWHNorm(x=0.2, y=0.1, w=0.5, h=0.5)
+
+# Convert to/from pixel coordinates
+from typus import to_xyxy_px, from_xyxy_px
+
+# To pixels (for 1920x1080 image)
+x1, y1, x2, y2 = to_xyxy_px(bbox, W=1920, H=1080)  
+# Result: (384, 108, 1344, 648)
+
+# From pixels
+bbox_from_pixels = from_xyxy_px(384, 108, 1344, 648, W=1920, H=1080)
+```
+
+### Legacy Geometry Types
+
+*The following types are maintained for backward compatibility but should not be used in new code.*
+
+#### `BBoxFormat` (Enum) - Legacy
+
+Defines the format of a legacy bounding box's coordinates.
 
 *   `XYXY_REL`: Relative coordinates representing [x_min, y_min, x_max, y_max], where values are fractions of image width/height.
 *   `XYXY_ABS`: Absolute pixel coordinates representing [x_min, y_min, x_max, y_max].
 *   `CXCYWH_REL`: Relative coordinates representing [center_x, center_y, width, height], where values are fractions of image width/height.
 *   `CXCYWH_ABS`: Absolute pixel coordinates representing [center_x, center_y, width, height].
 
-### `MaskEncoding` (Enum)
+#### `MaskEncoding` (Enum)
 
 Defines the encoding method for an instance mask.
 
@@ -28,24 +62,12 @@ Defines the encoding method for an instance mask.
 *   `POLYGON`: Polygon representation as a list of [x,y] points. The `data` field in `EncodedMask` will be a `List[List[float]]`.
 *   `PNG_BASE64`: Base64 encoded PNG image representing the mask. The `data` field in `EncodedMask` will be a string.
 
-### `BBox`
+#### `BBox` - Legacy
 
-Represents a bounding box.
+*Legacy bounding box with multiple format support. Use `BBoxXYWHNorm` for new code.*
 
 *   `coords: Tuple[float, float, float, float]`: The coordinates of the bounding box.
 *   `fmt: BBoxFormat = BBoxFormat.XYXY_REL`: The format of the coordinates. Defaults to relative XYXY.
-
-**Example:**
-
-```python
-from typus.models.geometry import BBox, BBoxFormat
-
-# Relative XYXY bounding box
-bbox_rel = BBox(coords=(0.1, 0.1, 0.5, 0.5))
-
-# Absolute XYXY bounding box
-bbox_abs = BBox(coords=(100, 50, 200, 150), fmt=BBoxFormat.XYXY_ABS)
-```
 
 ### `EncodedMask`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,8 @@ allow-plugins = true
 [tool.hatch.build]
 exclude = [
   "tests*",
-  "scripts*", 
+  "scripts*",
+  "dev*",            # Exclude development artifacts
   "**/*.tsv",
   "**/*.sql", 
   "**/*.sqlite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name            = "polli-typus"
-version         = "0.2.1"
+version         = "0.3.0"
 description     = "Taxonomic types, projections and async taxonomy services for Polli-Labs."
 readme          = { file = "README.md", content-type = "text/markdown" }
 license         = "MIT"

--- a/tests/test_geometry_bbox_norm.py
+++ b/tests/test_geometry_bbox_norm.py
@@ -1,0 +1,119 @@
+"""Tests for BBoxXYWHNorm canonical geometry type."""
+
+import pytest
+
+from typus.models.geometry import BBoxXYWHNorm
+
+
+class TestBBoxXYWHNormValidation:
+    """Test validation of canonical bbox constraints."""
+
+    def test_valid_bbox_creation(self):
+        """Test creating valid bboxes."""
+        # Normal case
+        bbox = BBoxXYWHNorm(x=0.1, y=0.2, w=0.5, h=0.6)
+        assert bbox.x == 0.1
+        assert bbox.y == 0.2
+        assert bbox.w == 0.5
+        assert bbox.h == 0.6
+
+    def test_boundary_cases(self):
+        """Test boundary value handling."""
+        # Minimum valid bbox
+        bbox1 = BBoxXYWHNorm(x=0.0, y=0.0, w=0.001, h=0.001)
+        assert bbox1.x == 0.0
+        assert bbox1.y == 0.0
+
+        # Maximum valid bbox (full image)
+        bbox2 = BBoxXYWHNorm(x=0.0, y=0.0, w=1.0, h=1.0)
+        assert bbox2.w == 1.0
+        assert bbox2.h == 1.0
+
+        # Edge case: x + w = 1 (should be allowed)
+        bbox3 = BBoxXYWHNorm(x=0.5, y=0.0, w=0.5, h=0.5)
+        assert bbox3.x + bbox3.w == 1.0
+
+    def test_frozen_immutability(self):
+        """Test that bbox is immutable after creation."""
+        bbox = BBoxXYWHNorm(x=0.1, y=0.2, w=0.5, h=0.6)
+        
+        with pytest.raises(TypeError):
+            bbox.x = 0.5  # Should raise error due to frozen=True
+
+    def test_coordinate_range_validation(self):
+        """Test coordinate range constraints."""
+        # x, y must be >= 0 and <= 1
+        with pytest.raises(ValueError):
+            BBoxXYWHNorm(x=-0.1, y=0.2, w=0.5, h=0.6)
+        
+        with pytest.raises(ValueError):
+            BBoxXYWHNorm(x=1.1, y=0.2, w=0.5, h=0.6)
+        
+        with pytest.raises(ValueError):
+            BBoxXYWHNorm(x=0.1, y=-0.1, w=0.5, h=0.6)
+        
+        with pytest.raises(ValueError):
+            BBoxXYWHNorm(x=0.1, y=1.1, w=0.5, h=0.6)
+
+    def test_size_validation(self):
+        """Test width and height constraints."""
+        # w, h must be > 0 and <= 1
+        with pytest.raises(ValueError):
+            BBoxXYWHNorm(x=0.1, y=0.2, w=0.0, h=0.6)
+        
+        with pytest.raises(ValueError):
+            BBoxXYWHNorm(x=0.1, y=0.2, w=-0.1, h=0.6)
+        
+        with pytest.raises(ValueError):
+            BBoxXYWHNorm(x=0.1, y=0.2, w=1.1, h=0.6)
+        
+        with pytest.raises(ValueError):
+            BBoxXYWHNorm(x=0.1, y=0.2, w=0.5, h=0.0)
+
+    def test_non_finite_rejection(self):
+        """Test rejection of non-finite coordinates."""
+        # NaN values
+        with pytest.raises(ValueError):
+            BBoxXYWHNorm(x=float('nan'), y=0.2, w=0.5, h=0.6)
+        
+        with pytest.raises(ValueError):
+            BBoxXYWHNorm(x=0.1, y=float('nan'), w=0.5, h=0.6)
+        
+        # Infinite values
+        with pytest.raises(ValueError):
+            BBoxXYWHNorm(x=float('inf'), y=0.2, w=0.5, h=0.6)
+        
+        with pytest.raises(ValueError):
+            BBoxXYWHNorm(x=0.1, y=0.2, w=float('-inf'), h=0.6)
+
+    def test_edge_case_epsilon_tolerance(self):
+        """Test handling of values very close to boundaries."""
+        # Values very close to 1.0 + epsilon should work
+        eps = 1e-9
+        bbox = BBoxXYWHNorm(x=0.5, y=0.5, w=0.5, h=0.5)
+        
+        # This should pass as x + w ≈ 1.0 within epsilon
+        bbox2 = BBoxXYWHNorm(x=0.5, y=0.5, w=0.5 - eps, h=0.5 - eps)
+        assert abs((bbox2.x + bbox2.w) - 1.0) < eps
+
+    def test_json_serialization(self):
+        """Test JSON serialization and deserialization."""
+        bbox = BBoxXYWHNorm(x=0.1, y=0.2, w=0.5, h=0.6)
+        
+        # Serialize to dict
+        bbox_dict = bbox.model_dump()
+        expected = {"x": 0.1, "y": 0.2, "w": 0.5, "h": 0.6}
+        assert bbox_dict == expected
+        
+        # Deserialize from dict
+        bbox_restored = BBoxXYWHNorm.model_validate(bbox_dict)
+        assert bbox_restored == bbox
+
+    def test_description_fields(self):
+        """Test that field descriptions are present in schema."""
+        schema = BBoxXYWHNorm.model_json_schema()
+        
+        assert "Left coordinate" in schema["properties"]["x"]["description"]
+        assert "Top coordinate" in schema["properties"]["y"]["description"]
+        assert "Width" in schema["properties"]["w"]["description"]
+        assert "Height" in schema["properties"]["h"]["description"]

--- a/tests/test_geometry_bbox_norm.py
+++ b/tests/test_geometry_bbox_norm.py
@@ -71,20 +71,44 @@ class TestBBoxXYWHNormValidation:
             BBoxXYWHNorm(x=0.1, y=0.2, w=0.5, h=0.0)
 
     def test_non_finite_rejection(self):
-        """Test rejection of non-finite coordinates."""
-        # NaN values
-        with pytest.raises(ValueError):
+        """Test rejection of non-finite coordinates with precise error messages."""
+        # NaN values with field-specific messages
+        with pytest.raises(ValueError, match="non-finite coordinate"):
             BBoxXYWHNorm(x=float('nan'), y=0.2, w=0.5, h=0.6)
         
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="non-finite coordinate"):
             BBoxXYWHNorm(x=0.1, y=float('nan'), w=0.5, h=0.6)
         
+        with pytest.raises(ValueError, match="non-finite coordinate"):
+            BBoxXYWHNorm(x=0.1, y=0.2, w=float('nan'), h=0.6)
+        
+        with pytest.raises(ValueError, match="non-finite coordinate"):
+            BBoxXYWHNorm(x=0.1, y=0.2, w=0.5, h=float('nan'))
+        
         # Infinite values
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="non-finite coordinate"):
             BBoxXYWHNorm(x=float('inf'), y=0.2, w=0.5, h=0.6)
         
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="non-finite coordinate"):
             BBoxXYWHNorm(x=0.1, y=0.2, w=float('-inf'), h=0.6)
+    
+    def test_bounds_exceeded_errors(self):
+        """Test specific error messages for bounds violations."""
+        # x + w > 1 + EPS
+        with pytest.raises(ValueError, match="x \\+ w exceeds 1"):
+            BBoxXYWHNorm(x=0.6, y=0.2, w=0.5, h=0.3)  # 0.6 + 0.5 = 1.1 > 1
+        
+        # y + h > 1 + EPS  
+        with pytest.raises(ValueError, match="y \\+ h exceeds 1"):
+            BBoxXYWHNorm(x=0.1, y=0.7, w=0.3, h=0.4)  # 0.7 + 0.4 = 1.1 > 1
+        
+        # Negative width
+        with pytest.raises(ValueError, match="greater than 0"):
+            BBoxXYWHNorm(x=0.1, y=0.2, w=-0.1, h=0.3)
+        
+        # Zero height  
+        with pytest.raises(ValueError, match="greater than 0"):
+            BBoxXYWHNorm(x=0.1, y=0.2, w=0.3, h=0.0)
 
     def test_edge_case_epsilon_tolerance(self):
         """Test handling of values very close to boundaries."""

--- a/tests/test_geometry_px_roundtrip.py
+++ b/tests/test_geometry_px_roundtrip.py
@@ -1,0 +1,161 @@
+"""Tests for pixel ↔ normalized bbox conversion round-trips."""
+
+import pytest
+
+from typus.models.geometry import BBoxXYWHNorm, from_xyxy_px, to_xyxy_px
+
+
+class TestPixelNormalizedRoundtrip:
+    """Test round-trip conversions between pixel and normalized coordinates."""
+
+    @pytest.mark.parametrize("W,H", [
+        (100, 100),      # Square
+        (1920, 1080),    # HD video
+        (640, 480),      # VGA
+        (3840, 2160),    # 4K
+        (1, 1),          # Edge case
+        (800, 600),      # 4:3 aspect ratio
+    ])
+    def test_roundtrip_accuracy(self, W: int, H: int):
+        """Test that pixel -> norm -> pixel conversion is accurate within 0.5px."""
+        # Test various bbox configurations
+        test_cases = [
+            # (x1, y1, x2, y2) in pixels
+            (10, 20, 50, 60),           # Small bbox
+            (0, 0, W//2, H//2),         # Top-left quadrant
+            (W//2, H//2, W, H),         # Bottom-right quadrant  
+            (0, 0, W, H),               # Full image
+            (W//4, H//4, 3*W//4, 3*H//4), # Centered box
+            (1, 1, 2, 2),               # Minimal size
+        ]
+        
+        for x1_orig, y1_orig, x2_orig, y2_orig in test_cases:
+            # Skip invalid cases
+            if x2_orig <= x1_orig or y2_orig <= y1_orig:
+                continue
+            if x1_orig < 0 or y1_orig < 0 or x2_orig > W or y2_orig > H:
+                continue
+            
+            # Convert pixels to normalized
+            bbox_norm = from_xyxy_px(x1_orig, y1_orig, x2_orig, y2_orig, W, H)
+            
+            # Convert back to pixels
+            x1_round, y1_round, x2_round, y2_round = to_xyxy_px(bbox_norm, W, H)
+            
+            # Check accuracy within 0.5 pixels
+            assert abs(x1_round - x1_orig) <= 0.5, f"x1 error: {abs(x1_round - x1_orig)}"
+            assert abs(y1_round - y1_orig) <= 0.5, f"y1 error: {abs(y1_round - y1_orig)}"
+            assert abs(x2_round - x2_orig) <= 0.5, f"x2 error: {abs(x2_round - x2_orig)}"
+            assert abs(y2_round - y2_orig) <= 0.5, f"y2 error: {abs(y2_round - y2_orig)}"
+
+    def test_edge_coordinates(self):
+        """Test conversion of edge and corner coordinates."""
+        W, H = 100, 100
+        
+        # Full image bbox
+        bbox = from_xyxy_px(0, 0, W, H, W, H)
+        assert bbox.x == 0.0
+        assert bbox.y == 0.0
+        assert bbox.w == 1.0  
+        assert bbox.h == 1.0
+        
+        # Convert back
+        x1, y1, x2, y2 = to_xyxy_px(bbox, W, H)
+        assert x1 == 0
+        assert y1 == 0
+        assert x2 == W
+        assert y2 == H
+
+    def test_small_bboxes(self):
+        """Test conversion of very small bboxes."""
+        W, H = 1000, 1000
+        
+        # 1-pixel bbox
+        bbox = from_xyxy_px(100, 200, 101, 201, W, H)
+        assert bbox.w == 1.0 / W
+        assert bbox.h == 1.0 / H
+        
+        # Convert back  
+        x1, y1, x2, y2 = to_xyxy_px(bbox, W, H)
+        assert abs(x1 - 100) <= 0.5
+        assert abs(y1 - 200) <= 0.5
+        assert abs(x2 - 101) <= 0.5
+        assert abs(y2 - 201) <= 0.5
+
+    def test_fractional_pixels(self):
+        """Test handling of fractional pixel coordinates."""
+        W, H = 100, 100
+        
+        # Fractional input coordinates
+        bbox = from_xyxy_px(10.3, 20.7, 50.9, 60.1, W, H)
+        
+        # Should create valid normalized bbox
+        assert 0 <= bbox.x <= 1
+        assert 0 <= bbox.y <= 1
+        assert 0 < bbox.w <= 1
+        assert 0 < bbox.h <= 1
+        
+        # Round-trip should be close
+        x1, y1, x2, y2 = to_xyxy_px(bbox, W, H)
+        assert abs(x1 - 10.3) <= 0.5
+        assert abs(y1 - 20.7) <= 0.5
+        assert abs(x2 - 50.9) <= 0.5
+        assert abs(y2 - 60.1) <= 0.5
+
+    def test_clamping_behavior(self):
+        """Test that out-of-bounds coordinates are clamped properly."""
+        W, H = 100, 100
+        
+        # Negative coordinates should be clamped to 0
+        bbox = from_xyxy_px(-10, -5, 50, 60, W, H)
+        assert bbox.x == 0.0
+        assert bbox.y == 0.0
+        
+        # Convert back - should stay clamped
+        x1, y1, x2, y2 = to_xyxy_px(bbox, W, H)
+        assert x1 == 0
+        assert y1 == 0
+
+    def test_invalid_xyxy_input(self):
+        """Test error handling for invalid xyxy input."""
+        W, H = 100, 100
+        
+        # x2 < x1
+        with pytest.raises(ValueError, match="xyxy invalid"):
+            from_xyxy_px(50, 20, 40, 60, W, H)
+        
+        # y2 < y1  
+        with pytest.raises(ValueError, match="xyxy invalid"):
+            from_xyxy_px(10, 60, 50, 50, W, H)
+        
+        # Equal coordinates (zero width/height)
+        with pytest.raises(ValueError, match="xyxy invalid"):
+            from_xyxy_px(10, 20, 10, 60, W, H)
+
+    def test_consistency_across_image_sizes(self):
+        """Test that normalized coordinates are consistent across different image sizes."""
+        # Same relative bbox in different image sizes
+        relative_coords = (0.1, 0.2, 0.5, 0.6)  # 10%, 20% to 50%, 60%
+        
+        image_sizes = [(100, 100), (200, 150), (1920, 1080)]
+        normalized_bboxes = []
+        
+        for W, H in image_sizes:
+            # Convert relative coords to pixels for this image size
+            x1 = int(relative_coords[0] * W)
+            y1 = int(relative_coords[1] * H) 
+            x2 = int(relative_coords[2] * W)
+            y2 = int(relative_coords[3] * H)
+            
+            # Create normalized bbox
+            bbox = from_xyxy_px(x1, y1, x2, y2, W, H)
+            normalized_bboxes.append(bbox)
+        
+        # All normalized bboxes should be very similar
+        # (small differences due to integer pixel quantization are expected)
+        base_bbox = normalized_bboxes[0]
+        for bbox in normalized_bboxes[1:]:
+            assert abs(bbox.x - base_bbox.x) < 0.01, "x coordinates should be similar"
+            assert abs(bbox.y - base_bbox.y) < 0.01, "y coordinates should be similar"
+            assert abs(bbox.w - base_bbox.w) < 0.01, "widths should be similar"
+            assert abs(bbox.h - base_bbox.h) < 0.01, "heights should be similar"

--- a/tests/test_models_canonical_bbox.py
+++ b/tests/test_models_canonical_bbox.py
@@ -1,0 +1,245 @@
+"""Tests for models using canonical bbox types (Detection, Track)."""
+
+import pytest
+
+from typus.models.geometry import BBoxXYWHNorm
+from typus.models.tracks import Detection, Track
+
+
+class TestDetectionCanonicalBbox:
+    """Test Detection model with canonical bbox support."""
+
+    def test_detection_with_canonical_bbox(self):
+        """Test creating Detection with canonical bbox_norm."""
+        bbox = BBoxXYWHNorm(x=0.1, y=0.2, w=0.3, h=0.4)
+        detection = Detection(
+            frame_number=100,
+            bbox_norm=bbox,
+            confidence=0.95
+        )
+        
+        assert detection.frame_number == 100
+        assert detection.bbox_norm == bbox
+        assert detection.confidence == 0.95
+        assert detection.bbox is None  # Legacy field not set
+
+    def test_detection_with_legacy_bbox(self):
+        """Test creating Detection with legacy bbox field."""
+        detection = Detection(
+            frame_number=50,
+            bbox=[10.0, 20.0, 30.0, 40.0],
+            confidence=0.85
+        )
+        
+        assert detection.frame_number == 50
+        assert detection.bbox == [10.0, 20.0, 30.0, 40.0]
+        assert detection.bbox_norm is None  # Canonical field not set
+        assert detection.confidence == 0.85
+
+    def test_detection_with_both_bbox_fields(self):
+        """Test Detection with both canonical and legacy bbox."""
+        bbox = BBoxXYWHNorm(x=0.1, y=0.2, w=0.3, h=0.4)
+        detection = Detection(
+            frame_number=75,
+            bbox_norm=bbox,
+            bbox=[10.0, 20.0, 30.0, 40.0],
+            confidence=0.90
+        )
+        
+        assert detection.bbox_norm == bbox
+        assert detection.bbox == [10.0, 20.0, 30.0, 40.0]
+
+    def test_detection_bbox_validation_error(self):
+        """Test that Detection requires at least one bbox field."""
+        with pytest.raises(ValueError, match="Either bbox_norm or bbox must be provided"):
+            Detection(
+                frame_number=100,
+                confidence=0.95
+                # No bbox_norm or bbox provided
+            )
+
+    def test_detection_from_raw_with_provider(self):
+        """Test Detection.from_raw_detection with provider mapping."""
+        # Mock raw detection with Gemini BR coordinates
+        raw_data = {
+            "frame_number": 100,
+            "bbox": [50, 50, 80, 90],  # BR xyxy coordinates
+            "confidence": 0.95,
+            "taxon_id": 47219
+        }
+        
+        # Convert using Gemini mapper
+        detection = Detection.from_raw_detection(
+            raw_data,
+            upload_w=100,
+            upload_h=100,
+            provider="gemini_br_xyxy"
+        )
+        
+        # Should have both canonical and legacy bbox
+        assert detection.bbox_norm is not None
+        assert detection.bbox == [50, 50, 80, 90]  # Legacy preserved
+        assert detection.frame_number == 100
+        assert detection.confidence == 0.95
+
+    def test_detection_from_raw_without_provider(self):
+        """Test Detection.from_raw_detection without provider (direct construction)."""
+        raw_data = {
+            "frame_number": 100,
+            "bbox_norm": {"x": 0.1, "y": 0.2, "w": 0.3, "h": 0.4},
+            "confidence": 0.95
+        }
+        
+        detection = Detection.from_raw_detection(raw_data)
+        
+        assert detection.bbox_norm.x == 0.1
+        assert detection.bbox_norm.y == 0.2
+        assert detection.bbox_norm.w == 0.3
+        assert detection.bbox_norm.h == 0.4
+
+    def test_detection_from_raw_missing_dimensions(self):
+        """Test error when provider requires but dimensions missing."""
+        raw_data = {
+            "frame_number": 100,
+            "bbox": [50, 50, 80, 90],
+            "confidence": 0.95
+        }
+        
+        with pytest.raises(ValueError, match="upload_w and upload_h required"):
+            Detection.from_raw_detection(raw_data, provider="gemini_br_xyxy")
+
+    def test_detection_smoothed_bbox_support(self):
+        """Test that Detection supports smoothed canonical bbox."""
+        bbox = BBoxXYWHNorm(x=0.1, y=0.2, w=0.3, h=0.4)
+        smoothed_bbox = BBoxXYWHNorm(x=0.11, y=0.21, w=0.29, h=0.39)
+        
+        detection = Detection(
+            frame_number=100,
+            bbox_norm=bbox,
+            smoothed_bbox_norm=smoothed_bbox,
+            confidence=0.95
+        )
+        
+        assert detection.bbox_norm == bbox
+        assert detection.smoothed_bbox_norm == smoothed_bbox
+
+
+class TestTrackWithCanonicalBbox:
+    """Test Track model with canonical bbox in detections."""
+
+    def test_track_with_canonical_detections(self):
+        """Test creating Track with canonical bbox detections."""
+        bbox1 = BBoxXYWHNorm(x=0.1, y=0.2, w=0.3, h=0.4)
+        bbox2 = BBoxXYWHNorm(x=0.15, y=0.25, w=0.25, h=0.35)
+        
+        detection1 = Detection(frame_number=100, bbox_norm=bbox1, confidence=0.95)
+        detection2 = Detection(frame_number=101, bbox_norm=bbox2, confidence=0.90)
+        
+        track = Track(
+            track_id="track_001",
+            clip_id="video_001",
+            detections=[detection1, detection2],
+            start_frame=100,
+            end_frame=101,
+            duration_frames=2,
+            duration_seconds=0.067,  # 2 frames at 30fps
+            confidence=0.925
+        )
+        
+        assert track.track_id == "track_001"
+        assert len(track.detections) == 2
+        assert track.detections[0].bbox_norm == bbox1
+        assert track.detections[1].bbox_norm == bbox2
+
+    def test_track_from_raw_detections(self):
+        """Test Track.from_raw_detections factory method."""
+        raw_detections = [
+            {
+                "frame_number": 100,
+                "bbox_norm": {"x": 0.1, "y": 0.2, "w": 0.3, "h": 0.4},
+                "confidence": 0.95
+            },
+            {
+                "frame_number": 101,
+                "bbox_norm": {"x": 0.15, "y": 0.25, "w": 0.25, "h": 0.35},
+                "confidence": 0.90
+            }
+        ]
+        
+        track = Track.from_raw_detections(
+            track_id="track_002",
+            clip_id="video_002", 
+            detections=raw_detections,
+            fps=30.0
+        )
+        
+        assert track.track_id == "track_002"
+        assert len(track.detections) == 2
+        assert track.start_frame == 100
+        assert track.end_frame == 101
+        assert track.duration_frames == 2
+        assert abs(track.duration_seconds - 2.0/30.0) < 1e-6
+
+    def test_track_mixed_bbox_types(self):
+        """Test Track with mix of canonical and legacy bbox detections."""
+        # One detection with canonical bbox
+        canonical_detection = Detection(
+            frame_number=100,
+            bbox_norm=BBoxXYWHNorm(x=0.1, y=0.2, w=0.3, h=0.4),
+            confidence=0.95
+        )
+        
+        # One detection with legacy bbox
+        legacy_detection = Detection(
+            frame_number=101,
+            bbox=[10.0, 20.0, 30.0, 40.0],
+            confidence=0.90
+        )
+        
+        track = Track(
+            track_id="track_mixed",
+            clip_id="video_mixed",
+            detections=[canonical_detection, legacy_detection],
+            start_frame=100,
+            end_frame=101,
+            duration_frames=2,
+            duration_seconds=0.067,
+            confidence=0.925
+        )
+        
+        assert track.detections[0].bbox_norm is not None
+        assert track.detections[0].bbox is None
+        assert track.detections[1].bbox_norm is None
+        assert track.detections[1].bbox is not None
+
+    def test_track_json_serialization_with_canonical(self):
+        """Test JSON serialization of Track with canonical bboxes."""
+        detection = Detection(
+            frame_number=100,
+            bbox_norm=BBoxXYWHNorm(x=0.1, y=0.2, w=0.3, h=0.4),
+            confidence=0.95
+        )
+        
+        track = Track(
+            track_id="track_json",
+            clip_id="video_json",
+            detections=[detection],
+            start_frame=100,
+            end_frame=100,
+            duration_frames=1,
+            duration_seconds=0.033,
+            confidence=0.95
+        )
+        
+        # Should serialize successfully
+        track_dict = track.model_dump()
+        
+        # Check that canonical bbox is in the output
+        det_dict = track_dict["detections"][0]
+        assert "bbox_norm" in det_dict
+        assert det_dict["bbox_norm"]["x"] == 0.1
+        assert det_dict["bbox_norm"]["y"] == 0.2
+        
+        # Should deserialize successfully
+        track_restored = Track.model_validate(track_dict)
+        assert track_restored.detections[0].bbox_norm.x == 0.1

--- a/tests/test_models_canonical_bbox.py
+++ b/tests/test_models_canonical_bbox.py
@@ -12,12 +12,8 @@ class TestDetectionCanonicalBbox:
     def test_detection_with_canonical_bbox(self):
         """Test creating Detection with canonical bbox_norm."""
         bbox = BBoxXYWHNorm(x=0.1, y=0.2, w=0.3, h=0.4)
-        detection = Detection(
-            frame_number=100,
-            bbox_norm=bbox,
-            confidence=0.95
-        )
-        
+        detection = Detection(frame_number=100, bbox_norm=bbox, confidence=0.95)
+
         assert detection.frame_number == 100
         assert detection.bbox_norm == bbox
         assert detection.confidence == 0.95
@@ -25,12 +21,8 @@ class TestDetectionCanonicalBbox:
 
     def test_detection_with_legacy_bbox(self):
         """Test creating Detection with legacy bbox field."""
-        detection = Detection(
-            frame_number=50,
-            bbox=[10.0, 20.0, 30.0, 40.0],
-            confidence=0.85
-        )
-        
+        detection = Detection(frame_number=50, bbox=[10.0, 20.0, 30.0, 40.0], confidence=0.85)
+
         assert detection.frame_number == 50
         assert detection.bbox == [10.0, 20.0, 30.0, 40.0]
         assert detection.bbox_norm is None  # Canonical field not set
@@ -40,12 +32,9 @@ class TestDetectionCanonicalBbox:
         """Test Detection with both canonical and legacy bbox."""
         bbox = BBoxXYWHNorm(x=0.1, y=0.2, w=0.3, h=0.4)
         detection = Detection(
-            frame_number=75,
-            bbox_norm=bbox,
-            bbox=[10.0, 20.0, 30.0, 40.0],
-            confidence=0.90
+            frame_number=75, bbox_norm=bbox, bbox=[10.0, 20.0, 30.0, 40.0], confidence=0.90
         )
-        
+
         assert detection.bbox_norm == bbox
         assert detection.bbox == [10.0, 20.0, 30.0, 40.0]
 
@@ -54,7 +43,7 @@ class TestDetectionCanonicalBbox:
         with pytest.raises(ValueError, match="Either bbox_norm or bbox must be provided"):
             Detection(
                 frame_number=100,
-                confidence=0.95
+                confidence=0.95,
                 # No bbox_norm or bbox provided
             )
 
@@ -65,17 +54,14 @@ class TestDetectionCanonicalBbox:
             "frame_number": 100,
             "bbox": [50, 50, 80, 90],  # BR xyxy coordinates
             "confidence": 0.95,
-            "taxon_id": 47219
+            "taxon_id": 47219,
         }
-        
+
         # Convert using Gemini mapper
         detection = Detection.from_raw_detection(
-            raw_data,
-            upload_w=100,
-            upload_h=100,
-            provider="gemini_br_xyxy"
+            raw_data, upload_w=100, upload_h=100, provider="gemini_br_xyxy"
         )
-        
+
         # Should have both canonical and legacy bbox
         assert detection.bbox_norm is not None
         assert detection.bbox == [50, 50, 80, 90]  # Legacy preserved
@@ -87,11 +73,11 @@ class TestDetectionCanonicalBbox:
         raw_data = {
             "frame_number": 100,
             "bbox_norm": {"x": 0.1, "y": 0.2, "w": 0.3, "h": 0.4},
-            "confidence": 0.95
+            "confidence": 0.95,
         }
-        
+
         detection = Detection.from_raw_detection(raw_data)
-        
+
         assert detection.bbox_norm.x == 0.1
         assert detection.bbox_norm.y == 0.2
         assert detection.bbox_norm.w == 0.3
@@ -99,61 +85,57 @@ class TestDetectionCanonicalBbox:
 
     def test_detection_from_raw_missing_dimensions(self):
         """Test error when provider requires but dimensions missing."""
-        raw_data = {
-            "frame_number": 100,
-            "bbox": [50, 50, 80, 90],
-            "confidence": 0.95
-        }
-        
+        raw_data = {"frame_number": 100, "bbox": [50, 50, 80, 90], "confidence": 0.95}
+
         with pytest.raises(ValueError, match="upload_w and upload_h required"):
             Detection.from_raw_detection(raw_data, provider="gemini_br_xyxy")
-    
+
     def test_detection_from_raw_bbox_disagreement(self):
         """Test error when bbox_norm and bbox disagree beyond tolerance."""
         raw_data = {
             "frame_number": 100,
-            "bbox_norm": {"x": 0.1, "y": 0.2, "w": 0.3, "h": 0.4},  # Would be ~(10,20,30,40) in 100x100
-            "bbox": [50, 60, 30, 40],  # Completely different bbox 
-            "confidence": 0.95
+            "bbox_norm": {
+                "x": 0.1,
+                "y": 0.2,
+                "w": 0.3,
+                "h": 0.4,
+            },  # Would be ~(10,20,30,40) in 100x100
+            "bbox": [50, 60, 30, 40],  # Completely different bbox
+            "confidence": 0.95,
         }
-        
+
         with pytest.raises(ValueError, match="bbox_norm and bbox disagree beyond tolerance"):
             Detection.from_raw_detection(raw_data, upload_w=100, upload_h=100)
-    
+
     def test_detection_from_raw_ambiguous_legacy(self):
         """Test error when legacy bbox provided without provider hint."""
         raw_data = {
             "frame_number": 100,
             "bbox": [50, 50, 80, 90],  # Ambiguous format
-            "confidence": 0.95
+            "confidence": 0.95,
         }
-        
+
         with pytest.raises(ValueError, match="Ambiguous legacy bbox format.*specify 'provider'"):
             Detection.from_raw_detection(raw_data, upload_w=100, upload_h=100)
-    
+
     def test_detection_from_raw_unknown_provider(self):
         """Test error when unknown provider specified."""
-        raw_data = {
-            "frame_number": 100,
-            "bbox": [50, 50, 80, 90],
-            "confidence": 0.95
-        }
-        
+        raw_data = {"frame_number": 100, "bbox": [50, 50, 80, 90], "confidence": 0.95}
+
         with pytest.raises(KeyError, match="No bbox mapper registered for 'unknown_provider'"):
-            Detection.from_raw_detection(raw_data, upload_w=100, upload_h=100, provider="unknown_provider")
+            Detection.from_raw_detection(
+                raw_data, upload_w=100, upload_h=100, provider="unknown_provider"
+            )
 
     def test_detection_smoothed_bbox_support(self):
         """Test that Detection supports smoothed canonical bbox."""
         bbox = BBoxXYWHNorm(x=0.1, y=0.2, w=0.3, h=0.4)
         smoothed_bbox = BBoxXYWHNorm(x=0.11, y=0.21, w=0.29, h=0.39)
-        
+
         detection = Detection(
-            frame_number=100,
-            bbox_norm=bbox,
-            smoothed_bbox_norm=smoothed_bbox,
-            confidence=0.95
+            frame_number=100, bbox_norm=bbox, smoothed_bbox_norm=smoothed_bbox, confidence=0.95
         )
-        
+
         assert detection.bbox_norm == bbox
         assert detection.smoothed_bbox_norm == smoothed_bbox
 
@@ -165,10 +147,10 @@ class TestTrackWithCanonicalBbox:
         """Test creating Track with canonical bbox detections."""
         bbox1 = BBoxXYWHNorm(x=0.1, y=0.2, w=0.3, h=0.4)
         bbox2 = BBoxXYWHNorm(x=0.15, y=0.25, w=0.25, h=0.35)
-        
+
         detection1 = Detection(frame_number=100, bbox_norm=bbox1, confidence=0.95)
         detection2 = Detection(frame_number=101, bbox_norm=bbox2, confidence=0.90)
-        
+
         track = Track(
             track_id="track_001",
             clip_id="video_001",
@@ -177,9 +159,9 @@ class TestTrackWithCanonicalBbox:
             end_frame=101,
             duration_frames=2,
             duration_seconds=0.067,  # 2 frames at 30fps
-            confidence=0.925
+            confidence=0.925,
         )
-        
+
         assert track.track_id == "track_001"
         assert len(track.detections) == 2
         assert track.detections[0].bbox_norm == bbox1
@@ -191,45 +173,38 @@ class TestTrackWithCanonicalBbox:
             {
                 "frame_number": 100,
                 "bbox_norm": {"x": 0.1, "y": 0.2, "w": 0.3, "h": 0.4},
-                "confidence": 0.95
+                "confidence": 0.95,
             },
             {
                 "frame_number": 101,
                 "bbox_norm": {"x": 0.15, "y": 0.25, "w": 0.25, "h": 0.35},
-                "confidence": 0.90
-            }
+                "confidence": 0.90,
+            },
         ]
-        
+
         track = Track.from_raw_detections(
-            track_id="track_002",
-            clip_id="video_002", 
-            detections=raw_detections,
-            fps=30.0
+            track_id="track_002", clip_id="video_002", detections=raw_detections, fps=30.0
         )
-        
+
         assert track.track_id == "track_002"
         assert len(track.detections) == 2
         assert track.start_frame == 100
         assert track.end_frame == 101
         assert track.duration_frames == 2
-        assert abs(track.duration_seconds - 2.0/30.0) < 1e-6
+        assert abs(track.duration_seconds - 2.0 / 30.0) < 1e-6
 
     def test_track_mixed_bbox_types(self):
         """Test Track with mix of canonical and legacy bbox detections."""
         # One detection with canonical bbox
         canonical_detection = Detection(
-            frame_number=100,
-            bbox_norm=BBoxXYWHNorm(x=0.1, y=0.2, w=0.3, h=0.4),
-            confidence=0.95
+            frame_number=100, bbox_norm=BBoxXYWHNorm(x=0.1, y=0.2, w=0.3, h=0.4), confidence=0.95
         )
-        
+
         # One detection with legacy bbox
         legacy_detection = Detection(
-            frame_number=101,
-            bbox=[10.0, 20.0, 30.0, 40.0],
-            confidence=0.90
+            frame_number=101, bbox=[10.0, 20.0, 30.0, 40.0], confidence=0.90
         )
-        
+
         track = Track(
             track_id="track_mixed",
             clip_id="video_mixed",
@@ -238,9 +213,9 @@ class TestTrackWithCanonicalBbox:
             end_frame=101,
             duration_frames=2,
             duration_seconds=0.067,
-            confidence=0.925
+            confidence=0.925,
         )
-        
+
         assert track.detections[0].bbox_norm is not None
         assert track.detections[0].bbox is None
         assert track.detections[1].bbox_norm is None
@@ -249,11 +224,9 @@ class TestTrackWithCanonicalBbox:
     def test_track_json_serialization_with_canonical(self):
         """Test JSON serialization of Track with canonical bboxes."""
         detection = Detection(
-            frame_number=100,
-            bbox_norm=BBoxXYWHNorm(x=0.1, y=0.2, w=0.3, h=0.4),
-            confidence=0.95
+            frame_number=100, bbox_norm=BBoxXYWHNorm(x=0.1, y=0.2, w=0.3, h=0.4), confidence=0.95
         )
-        
+
         track = Track(
             track_id="track_json",
             clip_id="video_json",
@@ -262,18 +235,18 @@ class TestTrackWithCanonicalBbox:
             end_frame=100,
             duration_frames=1,
             duration_seconds=0.033,
-            confidence=0.95
+            confidence=0.95,
         )
-        
+
         # Should serialize successfully
         track_dict = track.model_dump()
-        
+
         # Check that canonical bbox is in the output
         det_dict = track_dict["detections"][0]
         assert "bbox_norm" in det_dict
         assert det_dict["bbox_norm"]["x"] == 0.1
         assert det_dict["bbox_norm"]["y"] == 0.2
-        
+
         # Should deserialize successfully
         track_restored = Track.model_validate(track_dict)
         assert track_restored.detections[0].bbox_norm.x == 0.1

--- a/tests/test_provider_gemini_mapping.py
+++ b/tests/test_provider_gemini_mapping.py
@@ -13,7 +13,7 @@ class TestGeminiBRMapping:
         # Should be able to get the registered mapper
         mapper_fn = BBoxMapper.get("gemini_br_xyxy")
         assert callable(mapper_fn)
-        
+
         # Should be in the list of providers
         providers = BBoxMapper.list_providers()
         assert "gemini_br_xyxy" in providers
@@ -22,42 +22,42 @@ class TestGeminiBRMapping:
         """Test basic BR->TL coordinate conversion."""
         # Simple case: 100x100 image
         W, H = 100, 100
-        
+
         # Gemini BR coordinates (bottom-right origin)
         # If object is at top-left of image in our TL system,
         # in BR system it would be at (W-x2, H-y2) to (W-x1, H-y1)
-        
+
         # Expected TL bbox: x=0.2, y=0.1, w=0.3, h=0.4 (20,10 to 50,50 in 100x100)
         # In BR system: (100-50, 100-50) to (100-20, 100-10) = (50,50) to (80,90)
         x1_br, y1_br = 50, 50  # bottom-right origin
         x2_br, y2_br = 80, 90
-        
+
         mapper_fn = BBoxMapper.get("gemini_br_xyxy")
         bbox = mapper_fn(x1_br, y1_br, x2_br, y2_br, W, H)
-        
+
         # Resulting canonical bbox should be:
         # TL x1 = W - x2_br = 100 - 80 = 20
-        # TL y1 = H - y2_br = 100 - 90 = 10  
+        # TL y1 = H - y2_br = 100 - 90 = 10
         # TL x2 = W - x1_br = 100 - 50 = 50
         # TL y2 = H - y1_br = 100 - 50 = 50
         # Normalized: x=20/100=0.2, y=10/100=0.1, w=30/100=0.3, h=40/100=0.4
-        
+
         assert abs(bbox.x - 0.2) < 1e-6
-        assert abs(bbox.y - 0.1) < 1e-6  
+        assert abs(bbox.y - 0.1) < 1e-6
         assert abs(bbox.w - 0.3) < 1e-6
         assert abs(bbox.h - 0.4) < 1e-6
 
     def test_gemini_full_image_bbox(self):
         """Test conversion of full-image bbox from BR origin."""
         W, H = 200, 150
-        
+
         # Full image in BR coordinates: (0, 0) to (W, H)
         x1_br, y1_br = 0, 0
         x2_br, y2_br = W, H
-        
+
         mapper_fn = BBoxMapper.get("gemini_br_xyxy")
         bbox = mapper_fn(x1_br, y1_br, x2_br, y2_br, W, H)
-        
+
         # Should convert to full normalized bbox
         assert abs(bbox.x - 0.0) < 1e-6
         assert abs(bbox.y - 0.0) < 1e-6
@@ -68,17 +68,17 @@ class TestGeminiBRMapping:
         """Test edge cases for Gemini conversion."""
         W, H = 1000, 800
         mapper_fn = BBoxMapper.get("gemini_br_xyxy")
-        
+
         # Bottom-left corner in TL system = top-right in BR system
         # TL: (0, 700) to (100, 800) -> normalized (0, 0.875) to (0.1, 1.0)
         # BR: (900, 0) to (1000, 100)
         bbox = mapper_fn(900, 0, 1000, 100, W, H)
-        
+
         expected_x = 0.0
         expected_y = 0.875  # (800-100)/800
-        expected_w = 0.1    # 100/1000
+        expected_w = 0.1  # 100/1000
         expected_h = 0.125  # 100/800
-        
+
         assert abs(bbox.x - expected_x) < 1e-6
         assert abs(bbox.y - expected_y) < 1e-6
         assert abs(bbox.w - expected_w) < 1e-6
@@ -88,31 +88,31 @@ class TestGeminiBRMapping:
         """Test Gemini conversion with various image aspect ratios."""
         test_cases = [
             (1920, 1080),  # 16:9 HD
-            (1080, 1920),  # 9:16 portrait  
+            (1080, 1920),  # 9:16 portrait
             (1000, 1000),  # 1:1 square
-            (800, 600),    # 4:3 classic
+            (800, 600),  # 4:3 classic
             (2560, 1440),  # 16:9 QHD
         ]
-        
+
         mapper_fn = BBoxMapper.get("gemini_br_xyxy")
-        
+
         for W, H in test_cases:
             # Test a centered bbox: 25% to 75% in both dimensions
             # TL system: (0.25*W, 0.25*H) to (0.75*W, 0.75*H)
             tl_x1, tl_y1 = int(0.25 * W), int(0.25 * H)
             tl_x2, tl_y2 = int(0.75 * W), int(0.75 * H)
-            
+
             # Convert to BR coordinates
             br_x1 = W - tl_x2  # W - 0.75*W = 0.25*W
             br_y1 = H - tl_y2  # H - 0.75*H = 0.25*H
             br_x2 = W - tl_x1  # W - 0.25*W = 0.75*W
             br_y2 = H - tl_y1  # H - 0.25*H = 0.75*H
-            
+
             bbox = mapper_fn(br_x1, br_y1, br_x2, br_y2, W, H)
-            
+
             # Should result in approximately centered 50% bbox
             assert abs(bbox.x - 0.25) < 0.01
-            assert abs(bbox.y - 0.25) < 0.01  
+            assert abs(bbox.y - 0.25) < 0.01
             assert abs(bbox.w - 0.5) < 0.01
             assert abs(bbox.h - 0.5) < 0.01
 
@@ -120,7 +120,7 @@ class TestGeminiBRMapping:
         """Test that invalid Gemini coordinates raise appropriate errors."""
         mapper_fn = BBoxMapper.get("gemini_br_xyxy")
         W, H = 100, 100
-        
+
         # Invalid BR coordinates (x2 < x1 after conversion)
         # This should fail in from_xyxy_px validation
         with pytest.raises(ValueError):
@@ -129,29 +129,25 @@ class TestGeminiBRMapping:
 
 class TestBBoxMapperRegistry:
     """Test the BBoxMapper registry system."""
-    
+
     def test_register_custom_mapper(self):
         """Test registering a custom bbox mapper."""
+
         def custom_mapper(x1, y1, x2, y2, W, H) -> BBoxXYWHNorm:
             # Simple identity mapper (assumes input is already TL xyxy pixels)
-            return BBoxXYWHNorm(
-                x=x1 / W,
-                y=y1 / H, 
-                w=(x2 - x1) / W,
-                h=(y2 - y1) / H
-            )
-        
+            return BBoxXYWHNorm(x=x1 / W, y=y1 / H, w=(x2 - x1) / W, h=(y2 - y1) / H)
+
         # Register custom mapper
         BBoxMapper.register("test_custom", custom_mapper)
-        
+
         # Should be able to retrieve it
         retrieved = BBoxMapper.get("test_custom")
         assert retrieved == custom_mapper
-        
+
         # Should be in providers list
         providers = BBoxMapper.list_providers()
         assert "test_custom" in providers
-        
+
         # Should work when called
         bbox = retrieved(10, 20, 50, 60, 100, 100)
         assert bbox.x == 0.1
@@ -167,32 +163,33 @@ class TestBBoxMapperRegistry:
     def test_provider_list(self):
         """Test listing all registered providers."""
         providers = BBoxMapper.list_providers()
-        
+
         # Should contain at least the built-in Gemini mapper
         assert "gemini_br_xyxy" in providers
         assert isinstance(providers, list)
 
     def test_mapper_overwrite_protection(self):
         """Test that registering same name requires explicit replace=True."""
+
         def mapper1(x1, y1, x2, y2, W, H):
             return BBoxXYWHNorm(x=0.1, y=0.1, w=0.1, h=0.1)
-        
+
         def mapper2(x1, y1, x2, y2, W, H):
             return BBoxXYWHNorm(x=0.2, y=0.2, w=0.2, h=0.2)
-        
+
         # Register first mapper
         BBoxMapper.register("test_overwrite_protection", mapper1)
         result1 = BBoxMapper.get("test_overwrite_protection")(0, 0, 10, 10, 100, 100)
         assert result1.x == 0.1
-        
+
         # Try to register second mapper without replace=True (should fail)
         with pytest.raises(KeyError, match="already exists.*replace=True"):
             BBoxMapper.register("test_overwrite_protection", mapper2)
-        
+
         # Should still use first mapper
         result_still_1 = BBoxMapper.get("test_overwrite_protection")(0, 0, 10, 10, 100, 100)
         assert result_still_1.x == 0.1
-        
+
         # Register second mapper with explicit replace=True (should succeed)
         BBoxMapper.register("test_overwrite_protection", mapper2, replace=True)
         result2 = BBoxMapper.get("test_overwrite_protection")(0, 0, 10, 10, 100, 100)

--- a/tests/test_provider_gemini_mapping.py
+++ b/tests/test_provider_gemini_mapping.py
@@ -1,0 +1,191 @@
+"""Tests for provider-specific bbox mappings, especially Gemini BR/xyxy."""
+
+import pytest
+
+from typus.models.geometry import BBoxMapper, BBoxXYWHNorm
+
+
+class TestGeminiBRMapping:
+    """Test Gemini bottom-right origin to canonical TL-normalized conversion."""
+
+    def test_gemini_mapper_registration(self):
+        """Test that Gemini mapper is properly registered."""
+        # Should be able to get the registered mapper
+        mapper_fn = BBoxMapper.get("gemini_br_xyxy")
+        assert callable(mapper_fn)
+        
+        # Should be in the list of providers
+        providers = BBoxMapper.list_providers()
+        assert "gemini_br_xyxy" in providers
+
+    def test_simple_gemini_conversion(self):
+        """Test basic BR->TL coordinate conversion."""
+        # Simple case: 100x100 image
+        W, H = 100, 100
+        
+        # Gemini BR coordinates (bottom-right origin)
+        # If object is at top-left of image in our TL system,
+        # in BR system it would be at (W-x2, H-y2) to (W-x1, H-y1)
+        
+        # Expected TL bbox: x=0.2, y=0.1, w=0.3, h=0.4 (20,10 to 50,50 in 100x100)
+        # In BR system: (100-50, 100-50) to (100-20, 100-10) = (50,50) to (80,90)
+        x1_br, y1_br = 50, 50  # bottom-right origin
+        x2_br, y2_br = 80, 90
+        
+        mapper_fn = BBoxMapper.get("gemini_br_xyxy")
+        bbox = mapper_fn(x1_br, y1_br, x2_br, y2_br, W, H)
+        
+        # Resulting canonical bbox should be:
+        # TL x1 = W - x2_br = 100 - 80 = 20
+        # TL y1 = H - y2_br = 100 - 90 = 10  
+        # TL x2 = W - x1_br = 100 - 50 = 50
+        # TL y2 = H - y1_br = 100 - 50 = 50
+        # Normalized: x=20/100=0.2, y=10/100=0.1, w=30/100=0.3, h=40/100=0.4
+        
+        assert abs(bbox.x - 0.2) < 1e-6
+        assert abs(bbox.y - 0.1) < 1e-6  
+        assert abs(bbox.w - 0.3) < 1e-6
+        assert abs(bbox.h - 0.4) < 1e-6
+
+    def test_gemini_full_image_bbox(self):
+        """Test conversion of full-image bbox from BR origin."""
+        W, H = 200, 150
+        
+        # Full image in BR coordinates: (0, 0) to (W, H)
+        x1_br, y1_br = 0, 0
+        x2_br, y2_br = W, H
+        
+        mapper_fn = BBoxMapper.get("gemini_br_xyxy")
+        bbox = mapper_fn(x1_br, y1_br, x2_br, y2_br, W, H)
+        
+        # Should convert to full normalized bbox
+        assert abs(bbox.x - 0.0) < 1e-6
+        assert abs(bbox.y - 0.0) < 1e-6
+        assert abs(bbox.w - 1.0) < 1e-6
+        assert abs(bbox.h - 1.0) < 1e-6
+
+    def test_gemini_corner_cases(self):
+        """Test edge cases for Gemini conversion."""
+        W, H = 1000, 800
+        mapper_fn = BBoxMapper.get("gemini_br_xyxy")
+        
+        # Bottom-left corner in TL system = top-right in BR system
+        # TL: (0, 700) to (100, 800) -> normalized (0, 0.875) to (0.1, 1.0)
+        # BR: (900, 0) to (1000, 100)
+        bbox = mapper_fn(900, 0, 1000, 100, W, H)
+        
+        expected_x = 0.0
+        expected_y = 0.875  # (800-100)/800
+        expected_w = 0.1    # 100/1000
+        expected_h = 0.125  # 100/800
+        
+        assert abs(bbox.x - expected_x) < 1e-6
+        assert abs(bbox.y - expected_y) < 1e-6
+        assert abs(bbox.w - expected_w) < 1e-6
+        assert abs(bbox.h - expected_h) < 1e-6
+
+    def test_gemini_with_different_aspect_ratios(self):
+        """Test Gemini conversion with various image aspect ratios."""
+        test_cases = [
+            (1920, 1080),  # 16:9 HD
+            (1080, 1920),  # 9:16 portrait  
+            (1000, 1000),  # 1:1 square
+            (800, 600),    # 4:3 classic
+            (2560, 1440),  # 16:9 QHD
+        ]
+        
+        mapper_fn = BBoxMapper.get("gemini_br_xyxy")
+        
+        for W, H in test_cases:
+            # Test a centered bbox: 25% to 75% in both dimensions
+            # TL system: (0.25*W, 0.25*H) to (0.75*W, 0.75*H)
+            tl_x1, tl_y1 = int(0.25 * W), int(0.25 * H)
+            tl_x2, tl_y2 = int(0.75 * W), int(0.75 * H)
+            
+            # Convert to BR coordinates
+            br_x1 = W - tl_x2  # W - 0.75*W = 0.25*W
+            br_y1 = H - tl_y2  # H - 0.75*H = 0.25*H
+            br_x2 = W - tl_x1  # W - 0.25*W = 0.75*W
+            br_y2 = H - tl_y1  # H - 0.25*H = 0.75*H
+            
+            bbox = mapper_fn(br_x1, br_y1, br_x2, br_y2, W, H)
+            
+            # Should result in approximately centered 50% bbox
+            assert abs(bbox.x - 0.25) < 0.01
+            assert abs(bbox.y - 0.25) < 0.01  
+            assert abs(bbox.w - 0.5) < 0.01
+            assert abs(bbox.h - 0.5) < 0.01
+
+    def test_gemini_validation_failures(self):
+        """Test that invalid Gemini coordinates raise appropriate errors."""
+        mapper_fn = BBoxMapper.get("gemini_br_xyxy")
+        W, H = 100, 100
+        
+        # Invalid BR coordinates (x2 < x1 after conversion)
+        # This should fail in from_xyxy_px validation
+        with pytest.raises(ValueError):
+            mapper_fn(80, 50, 50, 90, W, H)  # Would create x2 < x1 in TL system
+
+
+class TestBBoxMapperRegistry:
+    """Test the BBoxMapper registry system."""
+    
+    def test_register_custom_mapper(self):
+        """Test registering a custom bbox mapper."""
+        def custom_mapper(x1, y1, x2, y2, W, H) -> BBoxXYWHNorm:
+            # Simple identity mapper (assumes input is already TL xyxy pixels)
+            return BBoxXYWHNorm(
+                x=x1 / W,
+                y=y1 / H, 
+                w=(x2 - x1) / W,
+                h=(y2 - y1) / H
+            )
+        
+        # Register custom mapper
+        BBoxMapper.register("test_custom", custom_mapper)
+        
+        # Should be able to retrieve it
+        retrieved = BBoxMapper.get("test_custom")
+        assert retrieved == custom_mapper
+        
+        # Should be in providers list
+        providers = BBoxMapper.list_providers()
+        assert "test_custom" in providers
+        
+        # Should work when called
+        bbox = retrieved(10, 20, 50, 60, 100, 100)
+        assert bbox.x == 0.1
+        assert bbox.y == 0.2
+        assert bbox.w == 0.4
+        assert bbox.h == 0.4
+
+    def test_nonexistent_mapper(self):
+        """Test error when requesting non-existent mapper."""
+        with pytest.raises(KeyError, match="No bbox mapper registered"):
+            BBoxMapper.get("nonexistent_mapper")
+
+    def test_provider_list(self):
+        """Test listing all registered providers."""
+        providers = BBoxMapper.list_providers()
+        
+        # Should contain at least the built-in Gemini mapper
+        assert "gemini_br_xyxy" in providers
+        assert isinstance(providers, list)
+
+    def test_mapper_overwrite(self):
+        """Test that registering same name overwrites previous mapper."""
+        def mapper1(x1, y1, x2, y2, W, H):
+            return BBoxXYWHNorm(x=0.1, y=0.1, w=0.1, h=0.1)
+        
+        def mapper2(x1, y1, x2, y2, W, H):
+            return BBoxXYWHNorm(x=0.2, y=0.2, w=0.2, h=0.2)
+        
+        # Register first mapper
+        BBoxMapper.register("test_overwrite", mapper1)
+        result1 = BBoxMapper.get("test_overwrite")(0, 0, 10, 10, 100, 100)
+        assert result1.x == 0.1
+        
+        # Register second mapper with same name
+        BBoxMapper.register("test_overwrite", mapper2)
+        result2 = BBoxMapper.get("test_overwrite")(0, 0, 10, 10, 100, 100)
+        assert result2.x == 0.2  # Should use the new mapper

--- a/typus/__init__.py
+++ b/typus/__init__.py
@@ -9,9 +9,9 @@ from .models.classification import (
     TaskPrediction,
     TaxonomyContext,
 )
+from .models.geometry import BBoxMapper, BBoxXYWHNorm, from_xyxy_px, to_xyxy_px
 from .models.lineage import LineageMap
 from .models.taxon import Taxon
-from .models.geometry import BBoxXYWHNorm, BBoxMapper, to_xyxy_px, from_xyxy_px
 from .models.tracks import Detection, Track, TrackStats
 from .services.elevation import ElevationService, PostgresRasterElevation
 from .services.projections import (

--- a/typus/__init__.py
+++ b/typus/__init__.py
@@ -11,6 +11,7 @@ from .models.classification import (
 )
 from .models.lineage import LineageMap
 from .models.taxon import Taxon
+from .models.geometry import BBoxXYWHNorm, BBoxMapper, to_xyxy_px, from_xyxy_px
 from .models.tracks import Detection, Track, TrackStats
 from .services.elevation import ElevationService, PostgresRasterElevation
 from .services.projections import (
@@ -36,6 +37,10 @@ __all__ = [
     "Taxon",
     "infer_rank",
     "LineageMap",
+    "BBoxXYWHNorm",
+    "BBoxMapper",
+    "to_xyxy_px",
+    "from_xyxy_px",
     "Detection",
     "Track",
     "TrackStats",

--- a/typus/export_schemas.py
+++ b/typus/export_schemas.py
@@ -11,6 +11,10 @@ MODELS = [
     "typus.models.classification.HierarchicalClassificationResult",
     "typus.models.geometry.BBox",
     "typus.models.geometry.EncodedMask",
+    "typus.models.geometry.BBoxXYWHNorm",
+    "typus.models.tracks.Detection",
+    "typus.models.tracks.Track",
+    "typus.models.tracks.TrackStats",
     "typus.models.detection.InstancePrediction",
     "typus.models.detection.ImageDetectionResult",
 ]

--- a/typus/models/__init__.py
+++ b/typus/models/__init__.py
@@ -1,9 +1,13 @@
 from .detection import ImageDetectionResult, InstancePrediction
-from .geometry import BBox, EncodedMask
+from .geometry import BBox, EncodedMask, BBoxXYWHNorm, BBoxMapper, to_xyxy_px, from_xyxy_px
 
 __all__ = [
     "BBox",
     "EncodedMask",
     "InstancePrediction",
     "ImageDetectionResult",
+    "BBoxXYWHNorm",
+    "BBoxMapper", 
+    "to_xyxy_px",
+    "from_xyxy_px",
 ]

--- a/typus/models/__init__.py
+++ b/typus/models/__init__.py
@@ -1,5 +1,5 @@
 from .detection import ImageDetectionResult, InstancePrediction
-from .geometry import BBox, EncodedMask, BBoxXYWHNorm, BBoxMapper, to_xyxy_px, from_xyxy_px
+from .geometry import BBox, BBoxMapper, BBoxXYWHNorm, EncodedMask, from_xyxy_px, to_xyxy_px
 
 __all__ = [
     "BBox",
@@ -7,7 +7,7 @@ __all__ = [
     "InstancePrediction",
     "ImageDetectionResult",
     "BBoxXYWHNorm",
-    "BBoxMapper", 
+    "BBoxMapper",
     "to_xyxy_px",
     "from_xyxy_px",
 ]

--- a/typus/models/geometry.py
+++ b/typus/models/geometry.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
 import enum
-from typing import List, Tuple
+from typing import Callable, Dict, List, Sequence, Tuple
 
-from pydantic import ConfigDict
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from .serialise import CompactJsonMixin
 
@@ -30,3 +31,134 @@ class EncodedMask(CompactJsonMixin):
     encoding: MaskEncoding
     bbox_hint: BBox | None = None
     model_config = ConfigDict(frozen=True)
+
+
+# Canonical geometry types for v0.3.0+
+EPS = 1e-9
+
+
+class BBoxXYWHNorm(BaseModel):
+    """Canonical TL-normalized bbox: [x, y, w, h] with invariants."""
+    x: float = Field(ge=0.0, le=1.0, description="Left coordinate (0-1, normalized)")
+    y: float = Field(ge=0.0, le=1.0, description="Top coordinate (0-1, normalized)")  
+    w: float = Field(gt=0.0, le=1.0, description="Width (0-1, normalized)")
+    h: float = Field(gt=0.0, le=1.0, description="Height (0-1, normalized)")
+
+    model_config = ConfigDict(frozen=True)
+
+    @field_validator("x", "y", "w", "h")
+    @classmethod
+    def _finite(cls, v: float) -> float:
+        if v != v or v in (float("inf"), float("-inf")):
+            raise ValueError("non-finite coordinate")
+        return v
+
+    @field_validator("w", "h")
+    @classmethod
+    def _bounds(cls, v: float, info) -> float:
+        # Access other values through info.data if available
+        if hasattr(info, 'data'):
+            x = info.data.get("x")
+            y = info.data.get("y")
+            w = info.data.get("w") if info.field_name == "h" else v
+            h = v if info.field_name == "h" else info.data.get("h")
+            
+            if x is not None and w is not None and x + w > 1.0 + EPS:
+                raise ValueError("x + w exceeds 1")
+            if y is not None and h is not None and y + h > 1.0 + EPS:
+                raise ValueError("y + h exceeds 1")
+        return v
+
+
+def to_xyxy_px(b: BBoxXYWHNorm, W: int, H: int) -> Tuple[int, int, int, int]:
+    """Convert canonical bbox to pixel XYXY coordinates."""
+    x1 = int(round(b.x * W))
+    y1 = int(round(b.y * H))
+    x2 = int(round((b.x + b.w) * W))
+    y2 = int(round((b.y + b.h) * H))
+    return x1, y1, x2, y2
+
+
+def from_xyxy_px(x1: float, y1: float, x2: float, y2: float, W: int, H: int) -> BBoxXYWHNorm:
+    """Convert pixel XYXY coordinates to canonical bbox."""
+    if x2 < x1 or y2 < y1:
+        raise ValueError("xyxy invalid: x2<x1 or y2<y1")
+    x = max(0.0, x1 / W)
+    y = max(0.0, y1 / H)
+    w = (x2 - x1) / W
+    h = (y2 - y1) / H
+    return BBoxXYWHNorm(x=x, y=y, w=w, h=h)
+
+
+class BBoxMapper:
+    """Registry for provider-specific bbox mapping functions."""
+    _REG: Dict[str, Callable[..., BBoxXYWHNorm]] = {}
+
+    @classmethod
+    def register(cls, name: str, fn: Callable[..., BBoxXYWHNorm]) -> None:
+        """Register a bbox mapping function."""
+        cls._REG[name] = fn
+
+    @classmethod
+    def get(cls, name: str) -> Callable[..., BBoxXYWHNorm]:
+        """Get a registered bbox mapping function."""
+        if name not in cls._REG:
+            raise KeyError(f"No bbox mapper registered for '{name}'")
+        return cls._REG[name]
+
+    @classmethod
+    def list_providers(cls) -> List[str]:
+        """List all registered provider names."""
+        return list(cls._REG.keys())
+
+
+def _gemini_br_xyxy_to_norm(x1_br: float, y1_br: float, x2_br: float, y2_br: float, W: int, H: int) -> BBoxXYWHNorm:
+    """Convert Gemini bottom-right origin XYXY to canonical TL-normalized XYWH.
+    
+    Gemini uses bottom-right origin where (0,0) is at bottom-right corner.
+    We convert to top-left pixel coordinates then normalize.
+    
+    Args:
+        x1_br, y1_br, x2_br, y2_br: Bottom-right origin pixel coordinates
+        W, H: Image dimensions in pixels
+        
+    Returns:
+        Canonical top-left normalized XYWH bbox
+    """
+    # Convert BR-origin coords to TL-origin pixel xyxy
+    # BR origin means (0,0) at bottom-right; TL pixel coords are:
+    tl_x1 = W - x2_br
+    tl_y1 = H - y2_br
+    tl_x2 = W - x1_br
+    tl_y2 = H - y1_br
+    return from_xyxy_px(tl_x1, tl_y1, tl_x2, tl_y2, W, H)
+
+
+# Register the Gemini BR->TL mapper
+BBoxMapper.register("gemini_br_xyxy", _gemini_br_xyxy_to_norm)
+
+
+def infer_from_raw(raw: Sequence[float] | dict, upload_w: int, upload_h: int, *, prefer: str = "tl_xywh_norm") -> BBoxXYWHNorm:
+    """Infer canonical bbox from raw data with strict validation.
+    
+    Only accepts obviously canonical TL-normalized xywh without provider hints.
+    For ambiguous formats, explicit provider mapping must be used.
+    
+    Args:
+        raw: Raw bbox data (list/tuple of 4 floats or dict)
+        upload_w, upload_h: Image dimensions (currently unused but kept for API consistency)
+        prefer: Preferred format hint (currently unused)
+        
+    Returns:
+        Canonical BBoxXYWHNorm
+        
+    Raises:
+        ValueError: If bbox format is ambiguous or invalid
+    """
+    if isinstance(raw, (list, tuple)) and len(raw) == 4:
+        x, y, w, h = raw
+        try:
+            return BBoxXYWHNorm(x=x, y=y, w=w, h=h)
+        except Exception:
+            pass
+    raise ValueError("Ambiguous bbox; specify provider or pass canonical TL-normalized xywh")

--- a/typus/models/geometry.py
+++ b/typus/models/geometry.py
@@ -95,8 +95,19 @@ class BBoxMapper:
     _REG: Dict[str, Callable[..., BBoxXYWHNorm]] = {}
 
     @classmethod
-    def register(cls, name: str, fn: Callable[..., BBoxXYWHNorm]) -> None:
-        """Register a bbox mapping function."""
+    def register(cls, name: str, fn: Callable[..., BBoxXYWHNorm], *, replace: bool = False) -> None:
+        """Register a bbox mapping function.
+        
+        Args:
+            name: Provider name identifier
+            fn: Mapping function that returns BBoxXYWHNorm
+            replace: If True, allows overwriting existing mappings
+            
+        Raises:
+            KeyError: If name already exists and replace=False
+        """
+        if name in cls._REG and not replace:
+            raise KeyError(f"Bbox mapper '{name}' already exists; pass replace=True to overwrite")
         cls._REG[name] = fn
 
     @classmethod

--- a/typus/models/geometry.py
+++ b/typus/models/geometry.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
+
 import enum
+import math
 from typing import Callable, Dict, List, Sequence, Tuple
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from .serialise import CompactJsonMixin
 
@@ -37,10 +39,20 @@ class EncodedMask(CompactJsonMixin):
 EPS = 1e-9
 
 
+def _round_half_up(x: float) -> int:
+    """Round to nearest integer with ties away from zero.
+
+    For non-negative inputs (our case), this is equivalent to ties-away-from-zero
+    as documented in the geometry contract.
+    """
+    return int(math.floor(x + 0.5))
+
+
 class BBoxXYWHNorm(BaseModel):
     """Canonical TL-normalized bbox: [x, y, w, h] with invariants."""
+
     x: float = Field(ge=0.0, le=1.0, description="Left coordinate (0-1, normalized)")
-    y: float = Field(ge=0.0, le=1.0, description="Top coordinate (0-1, normalized)")  
+    y: float = Field(ge=0.0, le=1.0, description="Top coordinate (0-1, normalized)")
     w: float = Field(gt=0.0, le=1.0, description="Width (0-1, normalized)")
     h: float = Field(gt=0.0, le=1.0, description="Height (0-1, normalized)")
 
@@ -53,56 +65,57 @@ class BBoxXYWHNorm(BaseModel):
             raise ValueError("non-finite coordinate")
         return v
 
-    @field_validator("w", "h")
-    @classmethod
-    def _bounds(cls, v: float, info) -> float:
-        # Access other values through info.data if available
-        if hasattr(info, 'data'):
-            x = info.data.get("x")
-            y = info.data.get("y")
-            w = info.data.get("w") if info.field_name == "h" else v
-            h = v if info.field_name == "h" else info.data.get("h")
-            
-            if x is not None and w is not None and x + w > 1.0 + EPS:
-                raise ValueError("x + w exceeds 1")
-            if y is not None and h is not None and y + h > 1.0 + EPS:
-                raise ValueError("y + h exceeds 1")
-        return v
+    @model_validator(mode="after")
+    def _validate_bounds(self) -> "BBoxXYWHNorm":
+        """Validate that bbox stays within [0,1] bounds."""
+        if self.x + self.w > 1.0 + EPS:
+            raise ValueError("x + w exceeds 1")
+        if self.y + self.h > 1.0 + EPS:
+            raise ValueError("y + h exceeds 1")
+        return self
 
 
 def to_xyxy_px(b: BBoxXYWHNorm, W: int, H: int) -> Tuple[int, int, int, int]:
     """Convert canonical bbox to pixel XYXY coordinates."""
-    x1 = int(round(b.x * W))
-    y1 = int(round(b.y * H))
-    x2 = int(round((b.x + b.w) * W))
-    y2 = int(round((b.y + b.h) * H))
+    x1 = _round_half_up(b.x * W)
+    y1 = _round_half_up(b.y * H)
+    x2 = _round_half_up((b.x + b.w) * W)
+    y2 = _round_half_up((b.y + b.h) * H)
     return x1, y1, x2, y2
 
 
 def from_xyxy_px(x1: float, y1: float, x2: float, y2: float, W: int, H: int) -> BBoxXYWHNorm:
     """Convert pixel XYXY coordinates to canonical bbox."""
-    if x2 < x1 or y2 < y1:
-        raise ValueError("xyxy invalid: x2<x1 or y2<y1")
+    if x2 <= x1 or y2 <= y1:
+        raise ValueError("xyxy invalid: x2<=x1 or y2<=y1")
     x = max(0.0, x1 / W)
     y = max(0.0, y1 / H)
     w = (x2 - x1) / W
     h = (y2 - y1) / H
+
+    # Clamp to [0,1] to avoid pathological float precision cases
+    x = min(1.0, max(0.0, x))
+    y = min(1.0, max(0.0, y))
+    w = min(1.0, max(EPS, w))
+    h = min(1.0, max(EPS, h))
+
     return BBoxXYWHNorm(x=x, y=y, w=w, h=h)
 
 
 class BBoxMapper:
     """Registry for provider-specific bbox mapping functions."""
+
     _REG: Dict[str, Callable[..., BBoxXYWHNorm]] = {}
 
     @classmethod
     def register(cls, name: str, fn: Callable[..., BBoxXYWHNorm], *, replace: bool = False) -> None:
         """Register a bbox mapping function.
-        
+
         Args:
             name: Provider name identifier
             fn: Mapping function that returns BBoxXYWHNorm
             replace: If True, allows overwriting existing mappings
-            
+
         Raises:
             KeyError: If name already exists and replace=False
         """
@@ -123,16 +136,18 @@ class BBoxMapper:
         return list(cls._REG.keys())
 
 
-def _gemini_br_xyxy_to_norm(x1_br: float, y1_br: float, x2_br: float, y2_br: float, W: int, H: int) -> BBoxXYWHNorm:
+def _gemini_br_xyxy_to_norm(
+    x1_br: float, y1_br: float, x2_br: float, y2_br: float, W: int, H: int
+) -> BBoxXYWHNorm:
     """Convert Gemini bottom-right origin XYXY to canonical TL-normalized XYWH.
-    
+
     Gemini uses bottom-right origin where (0,0) is at bottom-right corner.
     We convert to top-left pixel coordinates then normalize.
-    
+
     Args:
         x1_br, y1_br, x2_br, y2_br: Bottom-right origin pixel coordinates
         W, H: Image dimensions in pixels
-        
+
     Returns:
         Canonical top-left normalized XYWH bbox
     """
@@ -149,20 +164,22 @@ def _gemini_br_xyxy_to_norm(x1_br: float, y1_br: float, x2_br: float, y2_br: flo
 BBoxMapper.register("gemini_br_xyxy", _gemini_br_xyxy_to_norm)
 
 
-def infer_from_raw(raw: Sequence[float] | dict, upload_w: int, upload_h: int, *, prefer: str = "tl_xywh_norm") -> BBoxXYWHNorm:
+def infer_from_raw(
+    raw: Sequence[float] | dict, upload_w: int, upload_h: int, *, prefer: str = "tl_xywh_norm"
+) -> BBoxXYWHNorm:
     """Infer canonical bbox from raw data with strict validation.
-    
+
     Only accepts obviously canonical TL-normalized xywh without provider hints.
     For ambiguous formats, explicit provider mapping must be used.
-    
+
     Args:
         raw: Raw bbox data (list/tuple of 4 floats or dict)
         upload_w, upload_h: Image dimensions (currently unused but kept for API consistency)
         prefer: Preferred format hint (currently unused)
-        
+
     Returns:
         Canonical BBoxXYWHNorm
-        
+
     Raises:
         ValueError: If bbox format is ambiguous or invalid
     """

--- a/typus/models/tracks.py
+++ b/typus/models/tracks.py
@@ -12,7 +12,7 @@ from typing import Literal, Optional
 
 from pydantic import BaseModel, Field, model_validator
 
-from .geometry import BBoxXYWHNorm, BBoxMapper
+from .geometry import BBoxMapper, BBoxXYWHNorm
 
 
 class Detection(BaseModel):
@@ -24,18 +24,20 @@ class Detection(BaseModel):
     """
 
     frame_number: int = Field(..., ge=0, description="Frame number in the video")
-    
+
     # Canonical bbox (preferred)
     bbox_norm: BBoxXYWHNorm | None = Field(
         None, description="Canonical bounding box [x, y, w, h] - top-left origin, normalized [0,1]"
     )
-    
+
     # Legacy bbox field (deprecated)
     bbox: list[float] | None = Field(
-        None, min_length=4, max_length=4, 
-        description="Legacy pixel bbox [x, y, width, height] - DEPRECATED, use bbox_norm"
+        None,
+        min_length=4,
+        max_length=4,
+        description="Legacy pixel bbox [x, y, width, height] - DEPRECATED, use bbox_norm",
     )
-    
+
     confidence: float = Field(..., ge=0.0, le=1.0, description="Detection confidence score")
 
     # Optional taxonomy info (may be enriched post-detection)
@@ -54,56 +56,76 @@ class Detection(BaseModel):
         None, min_length=2, max_length=2, description="Velocity [vx, vy] in pixels/frame"
     )
 
-    @model_validator(mode='after')
-    def validate_bbox_fields(self) -> 'Detection':
+    @model_validator(mode="after")
+    def validate_bbox_fields(self) -> "Detection":
         """Ensure at least one bbox field is provided."""
         if self.bbox_norm is None and self.bbox is None:
             raise ValueError("Either bbox_norm or bbox must be provided")
         return self
 
     @classmethod
-    def from_raw_detection(cls, raw: dict, *, upload_w: int | None = None, upload_h: int | None = None, provider: str | None = None) -> 'Detection':
+    def from_raw_detection(
+        cls,
+        raw: dict,
+        *,
+        upload_w: int | None = None,
+        upload_h: int | None = None,
+        provider: str | None = None,
+    ) -> "Detection":
         """Create Detection from raw bbox data with optional provider mapping.
-        
+
+        When both bbox_norm (canonical) and bbox (legacy pixel) are present, this method
+        validates they agree within a 1.0 pixel tolerance. This accounts for rounding
+        differences due to the half-up rounding policy at pixel boundaries.
+
         Args:
             raw: Raw detection dictionary
             upload_w, upload_h: Image dimensions for provider mapping
             provider: Provider hint for bbox format conversion (e.g., 'gemini_br_xyxy')
-            
+
         Returns:
             Detection instance with canonical bbox_norm
-            
+
         Raises:
             ValueError: If provider mapping fails, dimensions missing, or bbox disagreement
         """
         detection_data = raw.copy()
-        
+
         # Handle bbox conversion if provider is specified
-        if 'bbox' in raw and provider is not None:
+        provider_mapping_used = False
+        if "bbox" in raw and provider is not None:
             if upload_w is None or upload_h is None:
                 raise ValueError("upload_w and upload_h required for provider mapping")
-            
+
             mapper_fn = BBoxMapper.get(provider)
-            bbox_data = raw['bbox']
+            bbox_data = raw["bbox"]
             if len(bbox_data) == 4:
                 canonical_bbox = mapper_fn(*bbox_data, upload_w, upload_h)
-                detection_data['bbox_norm'] = canonical_bbox
+                detection_data["bbox_norm"] = canonical_bbox
                 # Keep legacy bbox for compatibility
-                detection_data['bbox'] = bbox_data
-        
+                detection_data["bbox"] = bbox_data
+                provider_mapping_used = True
+
         # Validate agreement if both bbox_norm and bbox are present with dimensions
-        if ('bbox_norm' in detection_data and 'bbox' in detection_data and 
-            upload_w is not None and upload_h is not None):
-            bbox_norm = detection_data['bbox_norm']
+        # BUT skip validation if provider mapping was used (bbox is in provider format)
+        if (
+            "bbox_norm" in detection_data
+            and "bbox" in detection_data
+            and upload_w is not None
+            and upload_h is not None
+            and not provider_mapping_used
+        ):
+            bbox_norm = detection_data["bbox_norm"]
             if not isinstance(bbox_norm, BBoxXYWHNorm):
                 bbox_norm = BBoxXYWHNorm(**bbox_norm) if isinstance(bbox_norm, dict) else bbox_norm
-            
+
             # Convert canonical to pixel xywh for comparison
             from .geometry import to_xyxy_px
+
             x1, y1, x2, y2 = to_xyxy_px(bbox_norm, upload_w, upload_h)
             canonical_as_xywh = [x1, y1, x2 - x1, y2 - y1]
-            
-            legacy_bbox = detection_data['bbox']
+
+            legacy_bbox = detection_data["bbox"]
             if len(legacy_bbox) == 4:
                 # Allow 1-pixel tolerance for rounding differences
                 tolerance = 1.0
@@ -114,15 +136,20 @@ class Detection(BaseModel):
                         f"canonical_as_xywh={canonical_as_xywh}, legacy={legacy_bbox}, "
                         f"diffs={diffs}"
                     )
-        
-        # Require provider hint for ambiguous legacy bbox 
-        if ('bbox' in raw and 'bbox_norm' not in raw and provider is None and 
-            upload_w is not None and upload_h is not None):
+
+        # Require provider hint for ambiguous legacy bbox
+        if (
+            "bbox" in raw
+            and "bbox_norm" not in raw
+            and provider is None
+            and upload_w is not None
+            and upload_h is not None
+        ):
             raise ValueError(
                 "Ambiguous legacy bbox format detected. Please specify 'provider' parameter "
                 "(e.g., 'gemini_br_xyxy') or provide 'bbox_norm' directly for clarity."
             )
-            
+
         return cls(**detection_data)
 
     model_config = {

--- a/typus/schemas/BBoxXYWHNorm.json
+++ b/typus/schemas/BBoxXYWHNorm.json
@@ -1,0 +1,43 @@
+{
+  "$defs": {},
+  "additionalProperties": false,
+  "description": "Canonical TL-normalized bbox: [x, y, w, h] with invariants.",
+  "properties": {
+    "x": {
+      "description": "Left coordinate (0-1, normalized)",
+      "maximum": 1.0,
+      "minimum": 0.0,
+      "title": "X",
+      "type": "number"
+    },
+    "y": {
+      "description": "Top coordinate (0-1, normalized)",
+      "maximum": 1.0,
+      "minimum": 0.0,
+      "title": "Y", 
+      "type": "number"
+    },
+    "w": {
+      "description": "Width (0-1, normalized)",
+      "exclusiveMinimum": 0.0,
+      "maximum": 1.0,
+      "title": "W",
+      "type": "number"
+    },
+    "h": {
+      "description": "Height (0-1, normalized)",
+      "exclusiveMinimum": 0.0,
+      "maximum": 1.0,
+      "title": "H",
+      "type": "number"
+    }
+  },
+  "required": [
+    "x",
+    "y",
+    "w", 
+    "h"
+  ],
+  "title": "BBoxXYWHNorm",
+  "type": "object"
+}

--- a/typus/schemas/BBoxXYWHNorm.json
+++ b/typus/schemas/BBoxXYWHNorm.json
@@ -1,6 +1,4 @@
 {
-  "$defs": {},
-  "additionalProperties": false,
   "description": "Canonical TL-normalized bbox: [x, y, w, h] with invariants.",
   "properties": {
     "x": {
@@ -14,7 +12,7 @@
       "description": "Top coordinate (0-1, normalized)",
       "maximum": 1.0,
       "minimum": 0.0,
-      "title": "Y", 
+      "title": "Y",
       "type": "number"
     },
     "w": {
@@ -35,7 +33,7 @@
   "required": [
     "x",
     "y",
-    "w", 
+    "w",
     "h"
   ],
   "title": "BBoxXYWHNorm",

--- a/typus/schemas/Detection.json
+++ b/typus/schemas/Detection.json
@@ -1,0 +1,140 @@
+{
+  "$defs": {
+    "BBoxXYWHNorm": {
+      "additionalProperties": false,
+      "description": "Canonical TL-normalized bbox: [x, y, w, h] with invariants.",
+      "properties": {
+        "x": {
+          "description": "Left coordinate (0-1, normalized)",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "X",
+          "type": "number"
+        },
+        "y": {
+          "description": "Top coordinate (0-1, normalized)",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Y",
+          "type": "number"
+        },
+        "w": {
+          "description": "Width (0-1, normalized)",
+          "exclusiveMinimum": 0.0,
+          "maximum": 1.0,
+          "title": "W",
+          "type": "number"
+        },
+        "h": {
+          "description": "Height (0-1, normalized)",
+          "exclusiveMinimum": 0.0,
+          "maximum": 1.0,
+          "title": "H",
+          "type": "number"
+        }
+      },
+      "required": [
+        "x",
+        "y",
+        "w",
+        "h"
+      ],
+      "title": "BBoxXYWHNorm",
+      "type": "object"
+    }
+  },
+  "additionalProperties": true,
+  "description": "Single detection within a track.\n\nRepresents one observation of an object at a specific frame,\nincluding its bounding box, confidence score, and optional\ntaxonomic identification.",
+  "properties": {
+    "frame_number": {
+      "description": "Frame number in the video",
+      "minimum": 0,
+      "title": "Frame Number",
+      "type": "integer"
+    },
+    "bbox_norm": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/BBoxXYWHNorm"
+        }
+      ],
+      "default": null,
+      "description": "Canonical bounding box [x, y, w, h] - top-left origin, normalized [0,1]",
+      "title": "Bbox Norm"
+    },
+    "bbox": {
+      "default": null,
+      "description": "Legacy pixel bbox [x, y, width, height] - DEPRECATED, use bbox_norm",
+      "items": {
+        "type": "number"
+      },
+      "maxItems": 4,
+      "minItems": 4,
+      "title": "Bbox",
+      "type": "array"
+    },
+    "confidence": {
+      "description": "Detection confidence score",
+      "maximum": 1.0,
+      "minimum": 0.0,
+      "title": "Confidence",
+      "type": "number"
+    },
+    "taxon_id": {
+      "default": null,
+      "description": "Taxonomic ID from taxonomy service",
+      "title": "Taxon Id",
+      "type": "integer"
+    },
+    "scientific_name": {
+      "default": null,
+      "description": "Scientific name of detected organism",
+      "title": "Scientific Name",
+      "type": "string"
+    },
+    "common_name": {
+      "default": null,
+      "description": "Common name of detected organism",
+      "title": "Common Name",
+      "type": "string"
+    },
+    "smoothed_bbox": {
+      "default": null,
+      "description": "Smoothed bounding box after post-processing",
+      "items": {
+        "type": "number"
+      },
+      "maxItems": 4,
+      "minItems": 4,
+      "title": "Smoothed Bbox",
+      "type": "array"
+    },
+    "smoothed_bbox_norm": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/BBoxXYWHNorm"
+        }
+      ],
+      "default": null,
+      "description": "Smoothed canonical bbox after post-processing",
+      "title": "Smoothed Bbox Norm"
+    },
+    "velocity": {
+      "default": null,
+      "description": "Velocity [vx, vy] in pixels/frame",
+      "items": {
+        "type": "number"
+      },
+      "maxItems": 2,
+      "minItems": 2,
+      "title": "Velocity",
+      "type": "array"
+    }
+  },
+  "required": [
+    "frame_number",
+    "confidence"
+  ],
+  "title": "Detection",
+  "type": "object"
+}

--- a/typus/schemas/Detection.json
+++ b/typus/schemas/Detection.json
@@ -1,7 +1,6 @@
 {
   "$defs": {
     "BBoxXYWHNorm": {
-      "additionalProperties": false,
       "description": "Canonical TL-normalized bbox: [x, y, w, h] with invariants.",
       "properties": {
         "x": {
@@ -43,8 +42,20 @@
       "type": "object"
     }
   },
-  "additionalProperties": true,
   "description": "Single detection within a track.\n\nRepresents one observation of an object at a specific frame,\nincluding its bounding box, confidence score, and optional\ntaxonomic identification.",
+  "example": {
+    "bbox_norm": {
+      "h": 0.6,
+      "w": 0.5,
+      "x": 0.1,
+      "y": 0.2
+    },
+    "common_name": "Western honey bee",
+    "confidence": 0.95,
+    "frame_number": 100,
+    "scientific_name": "Apis mellifera",
+    "taxon_id": 47219
+  },
   "properties": {
     "frame_number": {
       "description": "Frame number in the video",
@@ -53,26 +64,34 @@
       "type": "integer"
     },
     "bbox_norm": {
-      "allOf": [
+      "anyOf": [
         {
           "$ref": "#/$defs/BBoxXYWHNorm"
+        },
+        {
+          "type": "null"
         }
       ],
       "default": null,
-      "description": "Canonical bounding box [x, y, w, h] - top-left origin, normalized [0,1]",
-      "title": "Bbox Norm"
+      "description": "Canonical bounding box [x, y, w, h] - top-left origin, normalized [0,1]"
     },
     "bbox": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "number"
+          },
+          "maxItems": 4,
+          "minItems": 4,
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "Legacy pixel bbox [x, y, width, height] - DEPRECATED, use bbox_norm",
-      "deprecated": true,
-      "items": {
-        "type": "number"
-      },
-      "maxItems": 4,
-      "minItems": 4,
-      "title": "Bbox (Legacy)",
-      "type": "array"
+      "title": "Bbox"
     },
     "confidence": {
       "description": "Detection confidence score",
@@ -82,55 +101,91 @@
       "type": "number"
     },
     "taxon_id": {
-      "default": null,
-      "description": "Taxonomic ID from taxonomy service",
-      "title": "Taxon Id",
-      "type": "integer"
-    },
-    "scientific_name": {
-      "default": null,
-      "description": "Scientific name of detected organism",
-      "title": "Scientific Name",
-      "type": "string"
-    },
-    "common_name": {
-      "default": null,
-      "description": "Common name of detected organism",
-      "title": "Common Name",
-      "type": "string"
-    },
-    "smoothed_bbox": {
-      "default": null,
-      "description": "Smoothed bounding box after post-processing - DEPRECATED, use smoothed_bbox_norm",
-      "deprecated": true,
-      "items": {
-        "type": "number"
-      },
-      "maxItems": 4,
-      "minItems": 4,
-      "title": "Smoothed Bbox (Legacy)",
-      "type": "array"
-    },
-    "smoothed_bbox_norm": {
-      "allOf": [
+      "anyOf": [
         {
-          "$ref": "#/$defs/BBoxXYWHNorm"
+          "type": "integer"
+        },
+        {
+          "type": "null"
         }
       ],
       "default": null,
-      "description": "Smoothed canonical bbox after post-processing",
-      "title": "Smoothed Bbox Norm"
+      "description": "Taxonomic ID from taxonomy service",
+      "title": "Taxon Id"
+    },
+    "scientific_name": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Scientific name of detected organism",
+      "title": "Scientific Name"
+    },
+    "common_name": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Common name of detected organism",
+      "title": "Common Name"
+    },
+    "smoothed_bbox": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "number"
+          },
+          "maxItems": 4,
+          "minItems": 4,
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Smoothed bounding box after post-processing",
+      "title": "Smoothed Bbox"
+    },
+    "smoothed_bbox_norm": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/BBoxXYWHNorm"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Smoothed canonical bbox after post-processing"
     },
     "velocity": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "number"
+          },
+          "maxItems": 2,
+          "minItems": 2,
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "Velocity [vx, vy] in pixels/frame",
-      "items": {
-        "type": "number"
-      },
-      "maxItems": 2,
-      "minItems": 2,
-      "title": "Velocity",
-      "type": "array"
+      "title": "Velocity"
     }
   },
   "required": [

--- a/typus/schemas/Detection.json
+++ b/typus/schemas/Detection.json
@@ -65,12 +65,13 @@
     "bbox": {
       "default": null,
       "description": "Legacy pixel bbox [x, y, width, height] - DEPRECATED, use bbox_norm",
+      "deprecated": true,
       "items": {
         "type": "number"
       },
       "maxItems": 4,
       "minItems": 4,
-      "title": "Bbox",
+      "title": "Bbox (Legacy)",
       "type": "array"
     },
     "confidence": {
@@ -100,13 +101,14 @@
     },
     "smoothed_bbox": {
       "default": null,
-      "description": "Smoothed bounding box after post-processing",
+      "description": "Smoothed bounding box after post-processing - DEPRECATED, use smoothed_bbox_norm",
+      "deprecated": true,
       "items": {
         "type": "number"
       },
       "maxItems": 4,
       "minItems": 4,
-      "title": "Smoothed Bbox",
+      "title": "Smoothed Bbox (Legacy)",
       "type": "array"
     },
     "smoothed_bbox_norm": {

--- a/typus/schemas/Track.json
+++ b/typus/schemas/Track.json
@@ -1,7 +1,6 @@
 {
   "$defs": {
     "BBoxXYWHNorm": {
-      "additionalProperties": false,
       "description": "Canonical TL-normalized bbox: [x, y, w, h] with invariants.",
       "properties": {
         "x": {
@@ -43,14 +42,251 @@
       "type": "object"
     },
     "Detection": {
-      "$ref": "./Detection.json"
+      "description": "Single detection within a track.\n\nRepresents one observation of an object at a specific frame,\nincluding its bounding box, confidence score, and optional\ntaxonomic identification.",
+      "example": {
+        "bbox_norm": {
+          "h": 0.6,
+          "w": 0.5,
+          "x": 0.1,
+          "y": 0.2
+        },
+        "common_name": "Western honey bee",
+        "confidence": 0.95,
+        "frame_number": 100,
+        "scientific_name": "Apis mellifera",
+        "taxon_id": 47219
+      },
+      "properties": {
+        "frame_number": {
+          "description": "Frame number in the video",
+          "minimum": 0,
+          "title": "Frame Number",
+          "type": "integer"
+        },
+        "bbox_norm": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BBoxXYWHNorm"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Canonical bounding box [x, y, w, h] - top-left origin, normalized [0,1]"
+        },
+        "bbox": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "number"
+              },
+              "maxItems": 4,
+              "minItems": 4,
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Legacy pixel bbox [x, y, width, height] - DEPRECATED, use bbox_norm",
+          "title": "Bbox"
+        },
+        "confidence": {
+          "description": "Detection confidence score",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Confidence",
+          "type": "number"
+        },
+        "taxon_id": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Taxonomic ID from taxonomy service",
+          "title": "Taxon Id"
+        },
+        "scientific_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Scientific name of detected organism",
+          "title": "Scientific Name"
+        },
+        "common_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Common name of detected organism",
+          "title": "Common Name"
+        },
+        "smoothed_bbox": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "number"
+              },
+              "maxItems": 4,
+              "minItems": 4,
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Smoothed bounding box after post-processing",
+          "title": "Smoothed Bbox"
+        },
+        "smoothed_bbox_norm": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BBoxXYWHNorm"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Smoothed canonical bbox after post-processing"
+        },
+        "velocity": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "number"
+              },
+              "maxItems": 2,
+              "minItems": 2,
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Velocity [vx, vy] in pixels/frame",
+          "title": "Velocity"
+        }
+      },
+      "required": [
+        "frame_number",
+        "confidence"
+      ],
+      "title": "Detection",
+      "type": "object"
     },
     "TrackStats": {
-      "$ref": "./TrackStats.json"
+      "description": "Statistical summary of track metrics.\n\nProvides aggregate statistics about a track's confidence scores\nand optionally other metrics like bounding box stability.",
+      "example": {
+        "bbox_stability": 0.88,
+        "confidence_max": 0.98,
+        "confidence_mean": 0.92,
+        "confidence_min": 0.85,
+        "confidence_std": 0.05
+      },
+      "properties": {
+        "confidence_mean": {
+          "description": "Mean confidence across all detections",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Confidence Mean",
+          "type": "number"
+        },
+        "confidence_std": {
+          "description": "Standard deviation of confidence scores",
+          "minimum": 0.0,
+          "title": "Confidence Std",
+          "type": "number"
+        },
+        "confidence_min": {
+          "description": "Minimum confidence score in track",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Confidence Min",
+          "type": "number"
+        },
+        "confidence_max": {
+          "description": "Maximum confidence score in track",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Confidence Max",
+          "type": "number"
+        },
+        "bbox_stability": {
+          "anyOf": [
+            {
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Measure of bounding box consistency (0=unstable, 1=stable)",
+          "title": "Bbox Stability"
+        }
+      },
+      "required": [
+        "confidence_mean",
+        "confidence_std",
+        "confidence_min",
+        "confidence_max"
+      ],
+      "title": "TrackStats",
+      "type": "object"
     }
   },
-  "additionalProperties": true,
   "description": "Complete track representing an object's journey through a video.\n\nA track consists of multiple detections linked across frames,\nrepresenting the same object as it moves through the video.\nIncludes aggregate metrics, taxonomic consensus, and validation metadata.",
+  "example": {
+    "clip_id": "video_20240108_1234",
+    "common_name": "Western honey bee",
+    "confidence": 0.92,
+    "detections": [
+      {
+        "bbox_norm": {
+          "h": 0.6,
+          "w": 0.5,
+          "x": 0.1,
+          "y": 0.2
+        },
+        "confidence": 0.95,
+        "frame_number": 100,
+        "taxon_id": 47219
+      }
+    ],
+    "detector": "yolov8",
+    "duration_frames": 150,
+    "duration_seconds": 5.0,
+    "end_frame": 250,
+    "scientific_name": "Apis mellifera",
+    "start_frame": 100,
+    "taxon_id": 47219,
+    "track_id": "track_001",
+    "tracker": "bytetrack",
+    "validation_status": "validated"
+  },
   "properties": {
     "track_id": {
       "description": "Unique identifier for this track",
@@ -91,7 +327,7 @@
     },
     "duration_seconds": {
       "description": "Duration in seconds",
-      "exclusiveMinimum": 0.0,
+      "exclusiveMinimum": 0,
       "title": "Duration Seconds",
       "type": "number"
     },
@@ -103,43 +339,158 @@
       "type": "number"
     },
     "stats": {
-      "allOf": [
+      "anyOf": [
         {
           "$ref": "#/$defs/TrackStats"
+        },
+        {
+          "type": "null"
         }
       ],
       "default": null,
-      "description": "Statistical summary of track metrics",
-      "title": "Stats"
+      "description": "Statistical summary of track metrics"
     },
     "taxon_id": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "Consensus taxonomic ID for the track",
-      "title": "Taxon Id",
-      "type": "integer"
+      "title": "Taxon Id"
     },
     "scientific_name": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "Consensus scientific name",
-      "title": "Scientific Name",
-      "type": "string"
+      "title": "Scientific Name"
     },
     "common_name": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "Consensus common name",
-      "title": "Common Name",
-      "type": "string"
+      "title": "Common Name"
     },
     "validation_status": {
+      "anyOf": [
+        {
+          "enum": [
+            "pending",
+            "validated",
+            "rejected"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": "pending",
       "description": "Human validation status",
-      "enum": [
-        "pending",
-        "validated",
-        "rejected"
+      "title": "Validation Status"
+    },
+    "validation_notes": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
       ],
-      "title": "Validation Status",
-      "type": "string"
+      "default": null,
+      "description": "Notes from validation process",
+      "title": "Validation Notes"
+    },
+    "validated_by": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Username/ID of validator",
+      "title": "Validated By"
+    },
+    "validated_at": {
+      "anyOf": [
+        {
+          "format": "date-time",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Timestamp of validation",
+      "title": "Validated At"
+    },
+    "detector": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Detection model used (e.g., 'yolov8', 'clip21')",
+      "title": "Detector"
+    },
+    "tracker": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Tracking algorithm used (e.g., 'sort', 'bytetrack')",
+      "title": "Tracker"
+    },
+    "smoothing_applied": {
+      "default": false,
+      "description": "Whether smoothing was applied to detections",
+      "title": "Smoothing Applied",
+      "type": "boolean"
+    },
+    "smoothing_method": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Smoothing method used (e.g., 'kalman', 'spline')",
+      "title": "Smoothing Method"
     }
   },
   "required": [

--- a/typus/schemas/Track.json
+++ b/typus/schemas/Track.json
@@ -1,0 +1,157 @@
+{
+  "$defs": {
+    "BBoxXYWHNorm": {
+      "additionalProperties": false,
+      "description": "Canonical TL-normalized bbox: [x, y, w, h] with invariants.",
+      "properties": {
+        "x": {
+          "description": "Left coordinate (0-1, normalized)",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "X",
+          "type": "number"
+        },
+        "y": {
+          "description": "Top coordinate (0-1, normalized)",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Y",
+          "type": "number"
+        },
+        "w": {
+          "description": "Width (0-1, normalized)",
+          "exclusiveMinimum": 0.0,
+          "maximum": 1.0,
+          "title": "W",
+          "type": "number"
+        },
+        "h": {
+          "description": "Height (0-1, normalized)",
+          "exclusiveMinimum": 0.0,
+          "maximum": 1.0,
+          "title": "H",
+          "type": "number"
+        }
+      },
+      "required": [
+        "x",
+        "y",
+        "w",
+        "h"
+      ],
+      "title": "BBoxXYWHNorm",
+      "type": "object"
+    },
+    "Detection": {
+      "$ref": "./Detection.json"
+    },
+    "TrackStats": {
+      "$ref": "./TrackStats.json"
+    }
+  },
+  "additionalProperties": true,
+  "description": "Complete track representing an object's journey through a video.\n\nA track consists of multiple detections linked across frames,\nrepresenting the same object as it moves through the video.\nIncludes aggregate metrics, taxonomic consensus, and validation metadata.",
+  "properties": {
+    "track_id": {
+      "description": "Unique identifier for this track",
+      "title": "Track Id",
+      "type": "string"
+    },
+    "clip_id": {
+      "description": "ID of the video clip containing this track",
+      "title": "Clip Id",
+      "type": "string"
+    },
+    "detections": {
+      "description": "List of detections forming this track",
+      "items": {
+        "$ref": "#/$defs/Detection"
+      },
+      "minItems": 1,
+      "title": "Detections",
+      "type": "array"
+    },
+    "start_frame": {
+      "description": "First frame of the track",
+      "minimum": 0,
+      "title": "Start Frame",
+      "type": "integer"
+    },
+    "end_frame": {
+      "description": "Last frame of the track",
+      "minimum": 0,
+      "title": "End Frame",
+      "type": "integer"
+    },
+    "duration_frames": {
+      "description": "Total frames in track",
+      "minimum": 1,
+      "title": "Duration Frames",
+      "type": "integer"
+    },
+    "duration_seconds": {
+      "description": "Duration in seconds",
+      "exclusiveMinimum": 0.0,
+      "title": "Duration Seconds",
+      "type": "number"
+    },
+    "confidence": {
+      "description": "Overall track confidence score",
+      "maximum": 1.0,
+      "minimum": 0.0,
+      "title": "Confidence",
+      "type": "number"
+    },
+    "stats": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/TrackStats"
+        }
+      ],
+      "default": null,
+      "description": "Statistical summary of track metrics",
+      "title": "Stats"
+    },
+    "taxon_id": {
+      "default": null,
+      "description": "Consensus taxonomic ID for the track",
+      "title": "Taxon Id",
+      "type": "integer"
+    },
+    "scientific_name": {
+      "default": null,
+      "description": "Consensus scientific name",
+      "title": "Scientific Name",
+      "type": "string"
+    },
+    "common_name": {
+      "default": null,
+      "description": "Consensus common name",
+      "title": "Common Name",
+      "type": "string"
+    },
+    "validation_status": {
+      "default": "pending",
+      "description": "Human validation status",
+      "enum": [
+        "pending",
+        "validated",
+        "rejected"
+      ],
+      "title": "Validation Status",
+      "type": "string"
+    }
+  },
+  "required": [
+    "track_id",
+    "clip_id",
+    "detections",
+    "start_frame",
+    "end_frame",
+    "duration_frames",
+    "duration_seconds",
+    "confidence"
+  ],
+  "title": "Track",
+  "type": "object"
+}

--- a/typus/schemas/TrackStats.json
+++ b/typus/schemas/TrackStats.json
@@ -1,6 +1,12 @@
 {
-  "additionalProperties": true,
   "description": "Statistical summary of track metrics.\n\nProvides aggregate statistics about a track's confidence scores\nand optionally other metrics like bounding box stability.",
+  "example": {
+    "bbox_stability": 0.88,
+    "confidence_max": 0.98,
+    "confidence_mean": 0.92,
+    "confidence_min": 0.85,
+    "confidence_std": 0.05
+  },
   "properties": {
     "confidence_mean": {
       "description": "Mean confidence across all detections",
@@ -30,12 +36,19 @@
       "type": "number"
     },
     "bbox_stability": {
+      "anyOf": [
+        {
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ],
       "default": null,
       "description": "Measure of bounding box consistency (0=unstable, 1=stable)",
-      "maximum": 1.0,
-      "minimum": 0.0,
-      "title": "Bbox Stability",
-      "type": "number"
+      "title": "Bbox Stability"
     }
   },
   "required": [

--- a/typus/schemas/TrackStats.json
+++ b/typus/schemas/TrackStats.json
@@ -1,0 +1,49 @@
+{
+  "additionalProperties": true,
+  "description": "Statistical summary of track metrics.\n\nProvides aggregate statistics about a track's confidence scores\nand optionally other metrics like bounding box stability.",
+  "properties": {
+    "confidence_mean": {
+      "description": "Mean confidence across all detections",
+      "maximum": 1.0,
+      "minimum": 0.0,
+      "title": "Confidence Mean",
+      "type": "number"
+    },
+    "confidence_std": {
+      "description": "Standard deviation of confidence scores",
+      "minimum": 0.0,
+      "title": "Confidence Std",
+      "type": "number"
+    },
+    "confidence_min": {
+      "description": "Minimum confidence score in track",
+      "maximum": 1.0,
+      "minimum": 0.0,
+      "title": "Confidence Min",
+      "type": "number"
+    },
+    "confidence_max": {
+      "description": "Maximum confidence score in track",
+      "maximum": 1.0,
+      "minimum": 0.0,
+      "title": "Confidence Max",
+      "type": "number"
+    },
+    "bbox_stability": {
+      "default": null,
+      "description": "Measure of bounding box consistency (0=unstable, 1=stable)",
+      "maximum": 1.0,
+      "minimum": 0.0,
+      "title": "Bbox Stability",
+      "type": "number"
+    }
+  },
+  "required": [
+    "confidence_mean",
+    "confidence_std",
+    "confidence_min",
+    "confidence_max"
+  ],
+  "title": "TrackStats",
+  "type": "object"
+}


### PR DESCRIPTION
## 🎯 **Lock-in Canonical Geometry Contract**

This PR delivers **typus v0.3.0** with canonical geometry types that establish typus as the **single source of truth** for bounding box coordinates across all Polli-Labs repositories.

## 📋 **Contract Established**

- **🎯 Origin**: Top-left corner (0,0) at upper-left of image
- **📏 Format**: `[x, y, width, height]` - never xyxy or center-based  
- **🔢 Normalization**: All values in `[0, 1]` range relative to image dimensions
- **🔒 Immutability**: `BBoxXYWHNorm` instances cannot be modified after creation
- **✅ Invariants**: Enforced at construction with precise error messages
- **🎚️ Tolerance**: Boundary checks use ε=1e-9 for floating-point precision
- **📐 Pixel Edges**: In pixel space, xyxy coordinates have **exclusive** x2/y2 bounds

## 🚀 **What's Added**

### **Canonical Geometry Types**
- **`BBoxXYWHNorm`**: Immutable canonical bbox with strict TL-normalized `[x,y,w,h]` validation
- **`BBoxMapper`**: Pluggable registry for provider-specific coordinate mappings  
- **Gemini Support**: Built-in `gemini_br_xyxy` mapper for bottom-right → top-left conversion
- **Conversion Utils**: `to_xyxy_px()` and `from_xyxy_px()` with sub-pixel accuracy

### **Enhanced Models** 
- **Detection Model**: Supports both `bbox_norm` (canonical) and `bbox` (legacy) fields
- **Factory Method**: `Detection.from_raw_detection()` with provider mapping support
- **Validation**: Agreement checks between canonical and legacy representations
- **Track Integration**: Updated examples to use canonical geometry

### **Complete Documentation**
- **`docs/geometry.md`**: Comprehensive usage guide with worked conversion examples
- **Contract Section**: Immutable coordinate system rules and edge semantics
- **Migration Guide**: Clear path from legacy pixel formats to canonical
- **Updated Models/Tracks**: Canonical examples replace legacy list[float] bboxes

### **Production Testing**
- **Validation Tests**: Boundary cases, immutability, finite value checking
- **Round-trip Tests**: Pixel ↔ normalized accuracy within 0.5px
- **Provider Tests**: Gemini BR→TL mapping with golden vectors
- **Negative Tests**: All error paths with precise message matching

### **API Safety** 
- **Protected Overwrites**: `BBoxMapper.register()` requires explicit `replace=True`
- **Agreement Validation**: Factory checks bbox consistency within tolerance
- **Explicit Failures**: Clear errors for ambiguous legacy formats
- **Deprecation Marking**: Legacy fields marked in JSON schemas

## 📊 **Backward Compatibility**

✅ **ZERO BREAKING CHANGES**
- All existing `bbox: list[float]` fields continue to work
- Existing `BBox` and geometry enums unchanged  
- No changes to public APIs or import paths

## 🔧 **Public API**

```python
# New canonical imports
from typus import BBoxXYWHNorm, BBoxMapper, to_xyxy_px, from_xyxy_px

# Create canonical bbox
bbox = BBoxXYWHNorm(x=0.2, y=0.1, w=0.5, h=0.5)

# Convert provider formats
detection = Detection.from_raw_detection(
    {"frame_number": 100, "bbox": [30, 40, 80, 90], "confidence": 0.95},
    upload_w=100, upload_h=100,
    provider="gemini_br_xyxy"
)
```

## 📦 **Release Artifacts**

- **JSON Schemas**: `BBoxXYWHNorm.json`, `Detection.json`, `Track.json`, `TrackStats.json`
- **Dev Exclusions**: `dev*` artifacts excluded from wheel packaging 
- **Security**: All credentials sanitized from documentation
- **Issue Tracking**: YAML-frontmatter issues with dependency relationships

## 🧪 **Testing**

- **4 new test files**: 100+ test cases covering all scenarios
- **Comprehensive coverage**: Validation, round-trips, provider mapping, models
- **Negative testing**: All error conditions with message validation
- **Golden vectors**: Representative coordinate system conversions

## 📚 **Documentation Updates**

- **New**: `docs/geometry.md` - Complete canonical geometry guide
- **Enhanced**: `docs/models.md` - Canonical types highlighted over legacy
- **Updated**: `docs/tracks.md` - Canonical bbox examples and provider mapping
- **Migration**: Clear upgrade path from pixel to normalized coordinates

## 🔗 **Issues Closed**

Closes: TYPUS-GEOM-0001, TYPUS-MODELS-0002, TYPUS-SCHEMA-0003, TYPUS-DOC-0004, TYPUS-REL-0005

## ⚡ **Impact**

This establishes typus as the canonical geometry authority, enabling:
- **Consistent coordinates** across all Polli-Labs repositories
- **Provider integration** with automatic format conversion
- **Strict validation** preventing coordinate system bugs
- **Future-proof contracts** with immutable type safety

## 🎯 **Next Steps**

After merge:
1. Tag and publish `v0.3.0` via existing CI/CD
2. Update ibrida to pin `typus >= 0.3.0` 
3. Remove duplicate canonical dataclasses from other repos

---

**Ready for org-wide canonical geometry adoption** 🚀