### PR TITLE
v0.4.1: ops helpers (bbox/tracks), docs, schema hook, mkdocstrings, NullPool fix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,8 @@ repos:
         language: system
         entry: pytest -q -k "not test_async_compatibility and not ancestry_verification and not ancestor_descendant_distance and not perf_name_search_local"
         pass_filenames: false
+      - id: export-schemas
+        name: export JSON Schemas (fail if stale)
+        language: system
+        entry: bash -lc 'uv run python -m typus.export_schemas && git diff --exit-code typus/schemas || (echo "\nSchemas changed. Please commit updated files." && exit 1)'
+        pass_filenames: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.4.1
+### Added
+- Introduced `typus.ops` with portable geometry and tracking helpers:
+  - Bounding box utilities: IoU (`iou_xyxy`), intersection (`intersect_xyxy`),
+    clamping (`clamp_xyxy`), area (`area_xyxy`).
+  - Pixel TL‑`xywh` converters complementing existing `xyxy` converters:
+    `to_xywh_px()` and `from_xywh_px()`.
+  - Tracking helpers: `group_detections_by_frame()` and
+    `detection_xyxy_px()` to convert a detection to pixel `xyxy`.
+### Docs
+- New page `docs/reference/ops.md` summarizing helpers with examples and
+  updated API index to include Ops.
+
 ## 0.4.0
 ### Removed
 - Legacy `ancestry`/`ancestry_str` support fully removed from ORM and services. Modern databases and fixtures omit this column; use helpers like `ancestors()` to compute lineage when needed.

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,10 @@ docs: ## Build docs with mkdocs (requires extras [docs])
 	uv pip install -e ".[docs]"
 	uv run mkdocs build
 
+schemas: ## Export JSON Schemas and show changes
+	uv run python -m typus.export_schemas
+	@git status --porcelain typus/schemas || true
+
 perf: ## Run name-search perf harness (writes dev/agents/perf_report.md)
 	TYPUS_PERF_WRITE=1 uv run python scripts/perf_report.py
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 **Shared taxonomy & geo‑temporal types for the Polli‑Labs ecological stack**
 
+Documentation: https://docs.polli.ai/typus
+
 Typus centralises every domain object that the rest of our platform —
 `linnaeus`, `pollinalysis-server`, dashboards … — needs: taxon records,
 clades, hierarchical classification results, projection helpers and async

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -4,65 +4,112 @@ This page describes how to set up a local development environment, run tests, an
 
 Environment
 
-- Python 3.10+ (CI tests run on 3.10, 3.11, 3.12)
-- Install dev extras with SQLite support:
+- Python 3.10+ (CI runs on 3.10, 3.11, 3.12)
+- Use `uv` and Makefile shortcuts (no plain `pip` in scripts/CI):
 
 ```
-pip install -e ".[dev,sqlite]"
+make dev-setup      # creates .venv (py310) and installs -e .[dev,sqlite]
+make dev-install    # installs pre-commit hooks
+```
+
+Formatting & Lint
+
+```
+make format         # uv run ruff format .
+make lint           # uv run ruff check --fix .
+```
+
+Tests
+
+Lightweight SQLite-backed tests (default for local dev and CI):
+
+```
+make ci
+```
+
+Full test suite (SQLite + any guarded tests that don’t require Postgres):
+
+```
+make test
+```
+
+Postgres-backed tests (optional, requires a running DB):
+
+```
+export TYPUS_TEST_DSN=postgresql+asyncpg://postgres:ooglyboogly69@localhost:5432/ibrida-v0
+export POSTGRES_DSN=$TYPUS_TEST_DSN
+export ELEVATION_DSN=$TYPUS_TEST_DSN
+export ELEVATION_TABLE=elevation_raster
+
+# Name search / PG subset (dataset-dependent)
+make test-pg
+
+# Elevation smoke tests (guarded; requires raster table)
+TYPUS_ELEVATION_TEST=1 uv run pytest -q -k elevation_service
+
+Important: avoid exporting `POSTGRES_DSN` when running the full suite unless
+you intend to run against the live database. Some tests (e.g. children/depth)
+assert counts that are specific to the SQLite sample fixture and will not match
+the full production dataset. The recommended workflow is:
+
+1) Run `make ci` / `make test` without `POSTGRES_DSN` to exercise SQLite.
+2) Run `make test-pg` for Postgres-specific coverage (name search, etc.).
+```
+
+Notes:
+
+- Ensure the Postgres database contains the required `expanded_taxa` table with the
+  recommended indexes. You can bootstrap indexes with:
+
+```
+uv run typus-pg-ensure-indexes
 ```
 
 Pre-commit
 
-- Install hooks:
-
 ```
-pre-commit install
+make dev-install
 ```
 
-- Hooks run on commit and in CI:
-  - ruff (lint only)
-  - ruff-format (auto-format; will fail the hook if it changes files)
-  - whitespace/yaml fixers
-  - pytest-lite (a fast subset; see below)
+Hooks run on commit and in CI:
+- ruff (lint)
+- ruff-format (check-only in CI)
+- whitespace/yaml fixers
+- pytest-lite (fast subset; mirrors `make ci` test selection)
 
-Tests
+JSON Schemas
 
-- Lightweight tests (default):
+If you add or change public Pydantic models, append the dotted path to
+`typus/export_schemas.py` and regenerate schemas:
 
 ```
-pytest -q -k "not test_async_compatibility.py and not test_ancestry_verification and not test_ancestor_descendant_distance and not test_perf_name_search_local"
+uv run python -m typus.export_schemas
 ```
 
-- Elevation smoke tests (Postgres only):
-  - Enable with `TYPUS_ELEVATION_TEST=1` and provide a DSN (`ELEVATION_DSN` or `TYPUS_TEST_DSN`).
-  - These are skipped by default in CI and pre-commit.
-
-- Postgres-backed tests (optional):
-  - Set `TYPUS_TEST_DSN` to enable connection (search, lineage, etc.).
-  - Keep these off in CI unless explicitly required.
+Generated JSON files live under `typus/schemas/` and are committed to the repo.
+Currently, schema export is a manual step (not enforced by CI).
 
 Perf Harness (optional)
-
-- Run with:
 
 ```
 make perf
 ```
 
-Writes a report to `dev/agents/perf_report.md`. You can enable `TYPUS_PERF_VERIFY=1` for strict checks, and `TYPUS_PERF_EXPLAIN=1` to append EXPLAIN snippets for Postgres.
+Writes a report to `dev/agents/perf_report.md`. You can enable `TYPUS_PERF_VERIFY=1` for strict checks,
+and `TYPUS_PERF_EXPLAIN=1` to append EXPLAIN snippets for Postgres.
 
 Service Backends
 
-- SQLite: For offline/dev, uses a cached fixture. Loader creates indexes by default.
-- Postgres: For production or full datasets. Use `typus-pg-ensure-indexes` to create recommended indexes.
+- SQLite: for offline/dev; loader creates indexes by default.
+- Postgres: for production or full datasets; `typus-pg-ensure-indexes` adds recommended indexes.
 - Elevation: Postgres-only; use `ELEVATION_DSN` and `ELEVATION_TABLE` (default `elevation_raster`).
 
 CI/CD Overview
 
 - CI workflow (`.github/workflows/ci.yml`):
   - Matrix on Python 3.10/3.11/3.12.
-  - Runs pre-commit (ruff, ruff-format, whitespace, pytest-lite) with --show-diff-on-failure.
-  - Then runs ruff format --check and ruff check.
+  - Runs pre-commit (ruff, ruff-format, whitespace, pytest-lite) with `--show-diff-on-failure`.
+  - Then runs `ruff format --check` and `ruff check`.
   - Runs a lightweight SQLite-backed pytest selection.
 - Publish workflow (`.github/workflows/publish.yml`):
   - Blocks build/publish on tests job.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,8 +2,12 @@
 
 Typus provides cross‑platform taxonomic models and asynchronous services for taxonomy queries.
 
-* **[Canonical Geometry](geometry.md)** – standardized bounding box formats and provider mappings (v0.3.0+)
-* **Taxonomy Service** – see [overview](taxonomy_service.md) and [Offline mode](offline_mode.md).
-* **[Models](models.md)** – detection and geometry data structures.
+* **[Canonical Geometry](geometry.md)** – standardized bbox formats and provider mappings.
+* **Taxonomy Service** – [overview](taxonomy_service.md) and [Offline mode](offline_mode.md).
+* **[Models](models.md)** – detection, geometry, and taxonomy data structures.
 * **[Tracks](tracks.md)** – object tracking models for video analysis.
+* **[Ops Helpers](reference/ops.md)** – portable bbox + tracking utilities.
+* **[API Reference](reference/api.md)** – auto-generated from docstrings (docs build).
+* **[Elevation Service](elevation_service.md)** – Postgres raster elevation helper.
+* **[Contributing](contributing.md)** – dev setup, lint/test flows.
 * **expanded_taxa schema** – details of the materialised view.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,0 +1,26 @@
+# API Reference (auto)
+
+::: typus.models.geometry
+    options:
+      members:
+        - BBoxXYWHNorm
+        - to_xyxy_px
+        - from_xyxy_px
+
+::: typus.ops.bbox
+    options:
+      members:
+        - iou_xyxy
+        - area_xyxy
+        - intersect_xyxy
+        - clamp_xyxy
+        - to_xywh_px
+        - from_xywh_px
+        - xyxy_to_xywh
+        - xywh_to_xyxy
+
+::: typus.ops.tracks
+    options:
+      members:
+        - group_detections_by_frame
+        - detection_xyxy_px

--- a/docs/reference/ops.md
+++ b/docs/reference/ops.md
@@ -1,0 +1,60 @@
+# Ops Helpers
+
+Lightweight utilities for common geometry and tracking operations. These are
+pure-Python helpers with no heavy dependencies and are designed to complement
+the canonical geometry in `typus.models.geometry` and the tracking models in
+`typus.models.tracks`.
+
+## Bounding Boxes (`typus.ops.bbox`)
+
+- `iou_xyxy(a, b) -> float` – IoU for pixel `xyxy` boxes. Returns `0.0` when
+  boxes are disjoint or just touching.
+- `area_xyxy(b) -> float` – Area in pixel^2; clamps negative extents to `0`.
+- `intersect_xyxy(a, b) -> tuple | None` – Intersection `xyxy` or `None` if no overlap.
+- `clamp_xyxy(b, W, H) -> tuple` – Clamp to `[0,W] × [0,H]`, preserving ordering.
+- `to_xywh_px(bbox_norm, W, H) -> tuple` – Convert normalized TL‑`xywh` to pixel TL‑`xywh`.
+- `from_xywh_px(x, y, w, h, W, H) -> BBoxXYWHNorm` – Convert pixel TL‑`xywh` to normalized.
+- `xyxy_to_xywh((x1,y1,x2,y2)) -> (x, y, w, h)` – Pixel‑space conversion.
+- `xywh_to_xyxy((x,y,w,h)) -> (x1, y1, x2, y2)` – Pixel‑space conversion.
+
+Example:
+
+```python
+from typus.models.geometry import BBoxXYWHNorm
+from typus.ops import iou_xyxy, to_xywh_px, from_xywh_px
+
+b = BBoxXYWHNorm(x=0.1, y=0.2, w=0.3, h=0.4)
+xywh_px = to_xywh_px(b, 640, 480)  # (64.0, 96.0, 192.0, 192.0)
+b2 = from_xywh_px(*xywh_px, 640, 480)
+assert b2 == b
+
+IoU = iou_xyxy((0,0,10,10), (5,5,15,15))
+```
+
+## Tracking (`typus.ops.tracks`)
+
+- `group_detections_by_frame(dets) -> dict[int, list[Detection]]` – Group by
+  `frame_number` with sorted keys; per‑frame order preserved.
+- `detection_xyxy_px(det, W, H) -> tuple` – Pixel `xyxy` for a `Detection`.
+  Prefers canonical `bbox_norm`; falls back to legacy pixel `bbox` when present.
+
+Example:
+
+```python
+from typus.models.geometry import BBoxXYWHNorm
+from typus.models.tracks import Detection
+from typus.ops import detection_xyxy_px, group_detections_by_frame
+
+d = Detection(frame_number=10, bbox_norm=BBoxXYWHNorm(x=0.1,y=0.2,w=0.4,h=0.5), confidence=0.9)
+xyxy = detection_xyxy_px(d, 1920, 1080)
+
+grouped = group_detections_by_frame([d])
+```
+
+## Design Principles
+
+- No heavy deps (no numpy in core helpers).
+- Return tuples for simple geometry to keep the surface area minimal.
+- Canonical model geometry is normalized TL‑`xywh`.
+- Pixel helpers are convenience utilities; they mirror semantics of
+  `typus.models.geometry` converters.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,20 @@ nav:
       - Offline mode: offline_mode.md
       - expanded_taxa schema: expanded_taxa.md
   - Models: models.md
-plugins: []
+  - Geometry: geometry.md
+  - Tracks: tracks.md
+  - Elevation Service: elevation_service.md
+  - Contributing: contributing.md
+  - Ops Helpers: reference/ops.md
+  - API Reference: reference/api.md
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            docstring_style: google
+            show_source: false
 markdown_extensions:
   - tables
   - admonition

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name            = "polli-typus"
-version         = "0.4.0"
+version         = "0.4.1"
 description     = "Taxonomic types, projections and async taxonomy services for Polli-Labs."
 readme          = { file = "README.md", content-type = "text/markdown" }
 license         = "MIT"
@@ -57,7 +57,12 @@ dev = [
 ]
 
 # Docs extra – everything you need to run `mkdocs build` or `mkdocs serve`
-docs = ["mkdocs>=1.6,<2", "mkdocs-material>=9.5,<10"]
+docs = [
+  "mkdocs>=1.6,<2",
+  "mkdocs-material>=9.5,<10",
+  "mkdocstrings>=0.24,<1",
+  "mkdocstrings-python>=1.10,<2"
+]
 
 [project.urls]
 Homepage   = "https://github.com/polli-labs/typus"

--- a/tests/ops/test_bbox.py
+++ b/tests/ops/test_bbox.py
@@ -1,0 +1,90 @@
+import math
+
+from typus.models.geometry import BBoxXYWHNorm, to_xyxy_px
+from typus.ops import (
+    area_xyxy,
+    clamp_xyxy,
+    from_xywh_px,
+    intersect_xyxy,
+    iou_xyxy,
+    to_xywh_px,
+    xywh_to_xyxy,
+    xyxy_to_xywh,
+)
+
+
+def test_iou_xyxy_basic_cases():
+    a = (0.0, 0.0, 10.0, 10.0)
+
+    # No overlap
+    b = (20.0, 20.0, 30.0, 30.0)
+    assert iou_xyxy(a, b) == 0.0
+
+    # Edge-touching => no overlap
+    b = (10.0, 0.0, 20.0, 10.0)
+    assert iou_xyxy(a, b) == 0.0
+
+    # Partial overlap
+    b = (5.0, 5.0, 15.0, 15.0)
+    # inter area = 5*5 = 25; union = 100 + 100 - 25 = 175
+    assert math.isclose(iou_xyxy(a, b), 25.0 / 175.0)
+
+    # Containment
+    b_small = (2.0, 2.0, 8.0, 8.0)  # area 36
+    assert math.isclose(iou_xyxy(a, b_small), 36.0 / 100.0)
+
+    # Identical
+    assert iou_xyxy(a, a) == 1.0
+
+
+def test_intersect_xyxy():
+    a = (0.0, 0.0, 10.0, 10.0)
+    b = (5.0, 5.0, 15.0, 15.0)
+    assert intersect_xyxy(a, b) == (5.0, 5.0, 10.0, 10.0)
+
+    # Disjoint
+    b = (20.0, 20.0, 30.0, 30.0)
+    assert intersect_xyxy(a, b) is None
+
+    # Edge-touching
+    b = (10.0, 0.0, 20.0, 10.0)
+    assert intersect_xyxy(a, b) is None
+
+
+def test_clamp_xyxy():
+    # Clamp negatives and overflows
+    clamped = clamp_xyxy((-5.0, -5.0, 12.0, 14.0), 10, 12)
+    assert clamped == (0.0, 0.0, 10.0, 12.0)
+
+    # Preserve ordering when inputs inverted
+    clamped2 = clamp_xyxy((10.0, 10.0, 5.0, 5.0), 20, 20)
+    assert clamped2 == (5.0, 5.0, 10.0, 10.0)
+
+
+def test_area_xyxy():
+    assert area_xyxy((0.0, 0.0, 10.0, 10.0)) == 100.0
+
+
+def test_xyxy_xywh_converters():
+    xyxy = (10.0, 20.0, 40.0, 60.0)
+    xywh = xyxy_to_xywh(xyxy)
+    assert xywh == (10.0, 20.0, 30.0, 40.0)
+    assert xywh_to_xyxy(xywh) == xyxy
+
+
+def test_xywh_px_roundtrip_and_consistency():
+    W, H = 640, 480
+    b = BBoxXYWHNorm(x=0.1, y=0.2, w=0.3, h=0.4)
+
+    # Round trip via xywh px
+    x, y, w, h = to_xywh_px(b, W, H)
+    b_rt = from_xywh_px(x, y, w, h, W, H)
+    assert math.isclose(b.x, b_rt.x, rel_tol=0, abs_tol=1e-9)
+    assert math.isclose(b.y, b_rt.y, rel_tol=0, abs_tol=1e-9)
+    assert math.isclose(b.w, b_rt.w, rel_tol=0, abs_tol=1e-9)
+    assert math.isclose(b.h, b_rt.h, rel_tol=0, abs_tol=1e-9)
+
+    # Consistency with existing xyxy converters
+    xyxy_direct = to_xyxy_px(b, W, H)
+    xyxy_via_rt = to_xyxy_px(b_rt, W, H)
+    assert xyxy_direct == xyxy_via_rt

--- a/tests/ops/test_ops_tracks.py
+++ b/tests/ops/test_ops_tracks.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typus.models.geometry import BBoxXYWHNorm, to_xyxy_px
+from typus.models.tracks import Detection
+from typus.ops import detection_xyxy_px, group_detections_by_frame
+
+
+def _det(frame: int, x: float, y: float, w: float, h: float, conf: float) -> Detection:
+    return Detection(
+        frame_number=frame,
+        bbox_norm=BBoxXYWHNorm(x=x, y=y, w=w, h=h),
+        confidence=conf,
+    )
+
+
+def test_group_detections_by_frame_unsorted_input_preserves_order_and_sorting():
+    dets = [
+        _det(2, 0.1, 0.1, 0.2, 0.2, 0.9),
+        _det(1, 0.2, 0.2, 0.2, 0.2, 0.8),
+        _det(2, 0.3, 0.3, 0.2, 0.2, 0.7),
+        _det(1, 0.4, 0.4, 0.2, 0.2, 0.6),
+        _det(3, 0.5, 0.5, 0.2, 0.2, 0.5),
+    ]
+
+    grouped = group_detections_by_frame(dets)
+    assert list(grouped.keys()) == [1, 2, 3]
+    # Per-frame order preserved
+    assert grouped[1][0] is dets[1]
+    assert grouped[1][1] is dets[3]
+    assert grouped[2][0] is dets[0]
+    assert grouped[2][1] is dets[2]
+    assert grouped[3][0] is dets[4]
+
+
+def test_detection_xyxy_px_matches_geometry_converter():
+    W, H = 1920, 1080
+    d = _det(10, 0.1, 0.2, 0.4, 0.5, 0.95)
+
+    xyxy_from_ops = detection_xyxy_px(d, W, H)
+    xyxy_from_geom = to_xyxy_px(d.bbox_norm, W, H)  # type: ignore[arg-type]
+    assert tuple(xyxy_from_geom) == xyxy_from_ops
+
+
+def test_detection_xyxy_px_legacy_bbox_fallback():
+    # Detection with only legacy pixel bbox (xywh)
+    d = Detection(frame_number=5, bbox=[10, 20, 30, 40], confidence=0.7)
+    assert detection_xyxy_px(d, 100, 100) == (10, 20, 40, 60)

--- a/typus/ops/__init__.py
+++ b/typus/ops/__init__.py
@@ -1,0 +1,44 @@
+"""Lightweight geometry and tracking helpers.
+
+These functions provide portable, dependency-light utilities that complement
+the canonical geometry types under `typus.models.geometry` and the
+tracking models under `typus.models.tracks`.
+
+Import convenience:
+
+    from typus.ops import (
+        iou_xyxy,
+        area_xyxy,
+        intersect_xyxy,
+        clamp_xyxy,
+        to_xywh_px,
+        from_xywh_px,
+        group_detections_by_frame,
+        detection_xyxy_px,
+    )
+"""
+
+from .bbox import (
+    area_xyxy,
+    clamp_xyxy,
+    from_xywh_px,
+    intersect_xyxy,
+    iou_xyxy,
+    to_xywh_px,
+    xywh_to_xyxy,
+    xyxy_to_xywh,
+)
+from .tracks import detection_xyxy_px, group_detections_by_frame
+
+__all__ = [
+    "iou_xyxy",
+    "area_xyxy",
+    "intersect_xyxy",
+    "clamp_xyxy",
+    "to_xywh_px",
+    "from_xywh_px",
+    "xyxy_to_xywh",
+    "xywh_to_xyxy",
+    "group_detections_by_frame",
+    "detection_xyxy_px",
+]

--- a/typus/ops/bbox.py
+++ b/typus/ops/bbox.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from typing import Tuple
+
+from typus.models.geometry import EPS, BBoxXYWHNorm
+
+
+def area_xyxy(b: Tuple[float, float, float, float]) -> float:
+    """Area of a pixel-space `xyxy` rectangle.
+
+    Negative extents are clamped to zero to be robust to degenerate inputs.
+    """
+    x1, y1, x2, y2 = b
+    w = max(0.0, x2 - x1)
+    h = max(0.0, y2 - y1)
+    return w * h
+
+
+def intersect_xyxy(
+    a: Tuple[float, float, float, float], b: Tuple[float, float, float, float]
+) -> Tuple[float, float, float, float] | None:
+    """Intersection rectangle of two `xyxy` boxes or `None` if disjoint/touching."""
+    ax1, ay1, ax2, ay2 = a
+    bx1, by1, bx2, by2 = b
+
+    x1 = max(ax1, bx1)
+    y1 = max(ay1, by1)
+    x2 = min(ax2, bx2)
+    y2 = min(ay2, by2)
+
+    if x2 <= x1 or y2 <= y1:
+        return None
+    return (x1, y1, x2, y2)
+
+
+def iou_xyxy(a: Tuple[float, float, float, float], b: Tuple[float, float, float, float]) -> float:
+    """Intersection over Union for two `xyxy` pixel-space boxes.
+
+    Returns 0.0 when there is no overlap (including edge-touching).
+    """
+    inter = intersect_xyxy(a, b)
+    if inter is None:
+        return 0.0
+
+    inter_area = area_xyxy(inter)
+    if inter_area <= 0.0:
+        return 0.0
+
+    a_area = area_xyxy(a)
+    b_area = area_xyxy(b)
+    union = a_area + b_area - inter_area
+    if union <= 0.0:
+        return 0.0
+    return inter_area / union
+
+
+def clamp_xyxy(
+    b: Tuple[float, float, float, float], W: int, H: int
+) -> Tuple[float, float, float, float]:
+    """Clamp an `xyxy` box to image bounds `[0,W] x [0,H]`.
+
+    Ordering is preserved so that the output always has `x1 <= x2` and `y1 <= y2`.
+    """
+    x1, y1, x2, y2 = b
+    x1 = min(max(0.0, x1), float(W))
+    y1 = min(max(0.0, y1), float(H))
+    x2 = min(max(0.0, x2), float(W))
+    y2 = min(max(0.0, y2), float(H))
+
+    # Ensure ordering in case the input was inverted
+    if x2 < x1:
+        x1, x2 = x2, x1
+    if y2 < y1:
+        y1, y2 = y2, y1
+    return (x1, y1, x2, y2)
+
+
+def to_xywh_px(bbox_norm: BBoxXYWHNorm, W: int, H: int) -> Tuple[float, float, float, float]:
+    """Convert normalized TL-`xywh` to pixel TL-`xywh` using image dimensions.
+
+    Uses simple scaling without rounding to preserve fractional pixel information.
+    """
+    return (
+        bbox_norm.x * W,
+        bbox_norm.y * H,
+        bbox_norm.w * W,
+        bbox_norm.h * H,
+    )
+
+
+def from_xywh_px(x: float, y: float, w: float, h: float, W: int, H: int) -> BBoxXYWHNorm:
+    """Convert pixel TL-`xywh` to normalized TL-`xywh` using image dimensions.
+
+    Values are clamped to `[0,1]` to avoid float precision edge cases, with a
+    minimal positive width/height enforced by the `BBoxXYWHNorm` model.
+    """
+    if w <= 0 or h <= 0:
+        raise ValueError("xywh invalid: non-positive width/height")
+
+    xn = max(0.0, x / W)
+    yn = max(0.0, y / H)
+    wn = w / W
+    hn = h / H
+
+    # Clamp to [0,1]
+    xn = min(1.0, max(0.0, xn))
+    yn = min(1.0, max(0.0, yn))
+    # Enforce minimal positive extents (mirror geometry.from_xyxy_px policy)
+    wn = min(1.0, max(EPS, wn))
+    hn = min(1.0, max(EPS, hn))
+
+    return BBoxXYWHNorm(x=xn, y=yn, w=wn, h=hn)
+
+
+def xyxy_to_xywh(b: Tuple[float, float, float, float]) -> Tuple[float, float, float, float]:
+    """Convert pixel-space `xyxy` → pixel TL-`xywh` (no clamping)."""
+    x1, y1, x2, y2 = b
+    return (x1, y1, x2 - x1, y2 - y1)
+
+
+def xywh_to_xyxy(b: Tuple[float, float, float, float]) -> Tuple[float, float, float, float]:
+    """Convert pixel TL-`xywh` → pixel-space `xyxy` (no clamping)."""
+    x, y, w, h = b
+    return (x, y, x + w, y + h)

--- a/typus/ops/tracks.py
+++ b/typus/ops/tracks.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Dict, Iterable, List, Tuple
+
+from typus.models.geometry import BBoxXYWHNorm, to_xyxy_px
+from typus.models.tracks import Detection
+
+
+def group_detections_by_frame(dets: Iterable[Detection]) -> Dict[int, List[Detection]]:
+    """Group detections by `frame_number` preserving per-frame order.
+
+    Returns a dict with integer keys sorted in ascending order.
+    """
+    tmp: Dict[int, List[Detection]] = defaultdict(list)
+    for d in dets:
+        # Detection.frame_number is required by the model; be robust to unexpected None
+        if d is None:  # type: ignore[unreachable]
+            continue
+        fn = int(getattr(d, "frame_number", 0))
+        tmp[fn].append(d)
+
+    return dict(sorted(tmp.items(), key=lambda kv: kv[0]))
+
+
+def detection_xyxy_px(det: Detection, W: int, H: int) -> Tuple[float, float, float, float]:
+    """Return pixel `xyxy` tuple for a `Detection` using image dimensions.
+
+    Prefers the canonical `bbox_norm` if present. If only the legacy `bbox`
+    (pixel `xywh`) is provided, falls back to converting that to `xyxy`.
+    """
+    if isinstance(det.bbox_norm, BBoxXYWHNorm):
+        return tuple(to_xyxy_px(det.bbox_norm, W, H))  # type: ignore[return-value]
+
+    if det.bbox and len(det.bbox) == 4:
+        x, y, w, h = det.bbox
+        return (x, y, x + w, y + h)
+
+    raise ValueError("Detection has neither bbox_norm nor legacy bbox")


### PR DESCRIPTION
Summary
- Add typus.ops with portable geometry + tracking helpers.
- New bbox helpers: IoU, area, intersection, clamp, xywh_px converters, and pixel-space xyxy<->xywh.
- Tracking helpers: group_detections_by_frame, detection_xyxy_px.
- Docs: Ops reference, API reference via mkdocstrings; sidebar parity; link to docs site in README; improved Contributing (flows + PG DSN guidance).
- Tooling: pre-commit schema export hook; Makefile schemas target; mkdocs docs extras.
- Taxonomy PG service: use NullPool to avoid asyncio loop mix-ups; keep children() async-gen + children_list() list wrapper.
- Version bump to 0.4.1.

Testing
- ruff format + ruff check: clean.
- SQLite/lightweight pytest subset: green.
- PG subset (name search) passes against live DB: set POSTGRES_DSN/TYPUS_TEST_DSN to postgresql+asyncpg://postgres:ooglyboogly69@localhost:5432/ibrida-v0.
- Note: some count assertions are fixture-specific; run full CI/SQLite suite without POSTGRES_DSN.

Docs build
- mkdocs builds; sidebar includes Geometry, Tracks, Elevation Service, Contributing, Ops Helpers, API Reference.

Follow-ups (optional)
- Consider extending CI to enforce schema export freshness (added pre-commit, no CI step yet).
- If desired, expand mkdocstrings coverage beyond ops/geometry.

Closes: dev/PRs/v0.4.1-PLAN.md; addresses dev/agents/v0.4.1/REVIEW.md feedback.