### PR TITLE
Use docs-brand latest + wordmarks

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,12 +4,12 @@ theme:
   features:
     - navigation.sections
     - navigation.top
-  logo: https://assets.polli.ai/docs-brand/v1.0.3/wordmarks/typus.svg
-  logo_dark: https://assets.polli.ai/docs-brand/v1.0.3/wordmarks/typus.svg
+  logo: https://assets.polli.ai/docs-brand/latest/wordmarks/typus.svg
+  logo_dark: https://assets.polli.ai/docs-brand/latest/wordmarks/typus.svg
 extra_css:
-  - https://assets.polli.ai/docs-brand/v1.0.3/polli-brand.css
+  - https://assets.polli.ai/docs-brand/latest/polli-brand.css
 extra_javascript:
-  - https://assets.polli.ai/docs-brand/v1.0.3/polli-brand.js
+  - https://assets.polli.ai/docs-brand/latest/polli-brand.js
 nav:
   - Home: index.md
   - Taxonomy Service:


### PR DESCRIPTION
Switch MkDocs brand kit references to `latest` and set theme wordmarks via the assets host.\n\n- extra_css / extra_javascript → https://assets.polli.ai/docs-brand/latest/\n- theme.logo / theme.logo_dark → assets wordmarks for this project\n\nRationale:\n- Avoids pinning to a specific kit version; enables immediate fixes.\n- Co-brand header is injected by polli-brand.js (wide: Polli + Product; narrow: Product).\n- Alt/labels set to "Polli {Product}".\n\nNo content changes; styling-only.