### PR TITLE
POL-692: harden Typus ty gate and bootstrap dev env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,22 +37,8 @@ jobs:
           uv venv
           uv pip install -e ".[dev,sqlite,loader]"
 
-      - name: Lint (ruff)
-        run: |
-          uv run ruff format --check .
-          uv run ruff check .
-
-      - name: Type check (ty)
-        run: |
-          make typecheck
-
-      - name: Schema freshness (export + diff)
-        run: |
-          uv run python -m typus.export_schemas
-          git diff --exit-code typus/schemas
-
-      - name: Run tests (SQLite fixture, no DSN)
+      - name: Canonical quality gate
         env:
           TYPUS_ELEVATION_TEST: "0"
         run: |
-          make ci
+          make check-all

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,20 +28,11 @@ jobs:
         run: |
           uv venv
           uv pip install -e ".[dev,sqlite,loader]"
-      - name: Lint (ruff)
-        run: |
-          make lint-check
-      - name: Type check (ty)
-        run: |
-          make typecheck
-      - name: Schema freshness (export + diff)
-        run: |
-          make schemas-check
-      - name: Run tests (SQLite fixture, no DSN)
+      - name: Canonical quality gate
         env:
           TYPUS_ELEVATION_TEST: "0"
         run: |
-          make ci
+          make check-all
 
   build-and-publish:
     needs: test

--- a/.gitignore
+++ b/.gitignore
@@ -181,7 +181,13 @@ expanded_taxa_06282025.tsv
 .venv/
 work/
 CLAUDE.md
-dev/
+dev/*
+!dev/agents/
+dev/agents/*
+!dev/agents/typus-v0.4.2-notes.md
+!dev/scripts/
+dev/scripts/*
+!dev/scripts/bootstrap-dev.sh
 AGENTS.md
 tests/expanded_taxa_sample.sqlite
 tests/sample_tsv/coldp_*.tsv

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help dev-setup dev-install lint lint-check typecheck format test test-fast ci test-pg-smoke test-pg schemas schemas-check typus-sqlite docs check-all quick clean
+.PHONY: help dev-setup dev-install lint lint-check typecheck format test test-fast ci test-pg-smoke test-pg pg-indexes schemas schemas-check typus-sqlite docs check-all quick perf clean
 
 # Colors
 BLUE := \033[0;34m
@@ -18,9 +18,10 @@ help: ## Show this help message
 	@echo '$(BLUE)Available targets:$(NC)'
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(GREEN)%-18s$(NC) %s\n", $$1, $$2}'
 
-dev-setup: ## Create venv and install dev + sqlite extras with uv
-	@echo "$(BLUE)Setting up venv (py310) and installing extras...$(NC)"
-	uv venv --python 3.10
+dev-setup: ## Ensure a py310 venv and install dev + sqlite + loader extras with uv
+	@echo "$(BLUE)Ensuring py310 via uv and syncing dev environment...$(NC)"
+	uv python install 3.10
+	uv venv --python 3.10 --allow-existing
 	uv pip install -e ".[dev,sqlite,loader]"
 	@echo "$(GREEN)✓ Environment ready$(NC)"
 
@@ -36,7 +37,7 @@ lint-check: ## Lint checks only (no auto-fixes)
 	uv run ruff format --check .
 	uv run ruff check .
 
-typecheck: ## Type-check package (ty)
+typecheck: ## Type-check runtime/tests/scripts with ty (warnings fail)
 	uv run ty check
 
 format: ## Format (ruff)
@@ -80,7 +81,7 @@ schemas-check: ## Verify schemas are fresh
 perf: ## Run name-search perf harness (writes dev/agents/perf_report.md)
 	TYPUS_PERF_WRITE=1 uv run python scripts/perf_report.py
 
-check-all: format lint typecheck test ## Format, lint, type-check, test
+check-all: lint-check typecheck schemas-check ci ## Canonical local quality gate (matches CI/publish)
 
 quick: format lint ## Format + lint only
 

--- a/README.md
+++ b/README.md
@@ -165,10 +165,18 @@ bee = await svc.get_taxon(630955)
 
 ## Developer guide
 
-* **Lint & tests (one‑liner)**
+Contributor setup and the canonical gate live in [`docs/contributing.md`](docs/contributing.md).
+
+* **Bootstrap the repo-local dev environment**
 
   ```bash
-  make format && make lint && make typecheck && make test
+  ./dev/scripts/bootstrap-dev.sh
+  ```
+
+* **Run the canonical local quality gate**
+
+  ```bash
+  make check-all
   ```
 
 * **Format whole repo**
@@ -179,6 +187,7 @@ bee = await svc.get_taxon(630955)
 
 * **JSON Schemas** – `make schemas` → `typus/schemas/`
 * **Type checking** – `make typecheck`
+* **Contributor guide** – `docs/contributing.md`
 
 * **SQLite fixture** – `uv run python scripts/gen_fixture_sqlite.py`
 

--- a/dev/scripts/bootstrap-dev.sh
+++ b/dev/scripts/bootstrap-dev.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "${script_dir}/../.." && pwd)"
+
+cd "${repo_root}"
+
+require_cmd() {
+    local cmd="$1"
+    if ! command -v "${cmd}" >/dev/null 2>&1; then
+        printf 'missing required command: %s\n' "${cmd}" >&2
+        exit 1
+    fi
+}
+
+require_cmd git
+require_cmd make
+require_cmd uv
+
+if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
+    printf 'not inside a git worktree: %s\n' "${repo_root}" >&2
+    exit 1
+fi
+
+if ! uv python find 3.10 >/dev/null 2>&1; then
+    printf 'Installing Python 3.10 via uv...\n'
+    uv python install 3.10
+fi
+
+make dev-setup
+make dev-install
+
+printf '\nBootstrap complete.\n'
+printf 'Next step: make check-all\n'

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -6,6 +6,13 @@ Environment
 
 - Python 3.10+ (CI runs on 3.10, 3.11, 3.12)
 - Use `uv` and Makefile shortcuts (no plain `pip` in scripts/CI):
+- Preferred bootstrap path for contributors:
+
+```
+./dev/scripts/bootstrap-dev.sh   # ensures uv + Python 3.10, syncs .venv, installs hooks
+```
+
+- Lower-level env sync targets remain available when you only need to refresh part of the setup:
 
 ```
 make dev-setup      # creates .venv (py310) and installs -e .[dev,sqlite,loader]
@@ -17,23 +24,30 @@ Formatting & Lint
 ```
 make format         # uv run ruff format .
 make lint           # uv run ruff check --fix .
+make lint-check     # uv run ruff format --check . && uv run ruff check .
 ```
 
 Type checking
 
 ```
-make typecheck      # uv run ty check
+make typecheck      # uv run ty check (warnings fail)
+```
+
+Canonical local quality gate
+
+```
+make check-all      # lint-check + typecheck + schemas-check + ci
 ```
 
 Tests
 
-Lightweight SQLite-backed tests (default for local dev and CI):
+Lightweight SQLite-backed tests that match the CI gate:
 
 ```
 make ci
 ```
 
-Default test suite (SQLite + tests that do not require optional Postgres access):
+Broader default local suite (SQLite + tests that do not require optional Postgres access):
 
 ```
 make test
@@ -117,10 +131,9 @@ CI/CD Overview
 
 - CI workflow (`.github/workflows/ci.yml`):
   - Matrix on Python 3.10/3.11/3.12.
-  - Runs `ruff format --check` and `ruff check`.
-  - Runs `ty` type checks via `make typecheck`.
-  - Runs schema freshness checks and a lightweight SQLite-backed pytest selection.
+  - Installs dev dependencies, then runs `make check-all`.
+  - `make check-all` covers `make lint-check`, `make typecheck`, `make schemas-check`, and `make ci`.
   - Triggers on PRs and pushes to `main` (to avoid duplicate branch + PR runs for the same commit).
 - Publish workflow (`.github/workflows/publish.yml`):
-  - Blocks build/publish on tests job (ruff + ty + schemas + SQLite test selection).
+  - Blocks build/publish on the same `make check-all` gate used locally and in CI.
   - Builds and uploads wheels, then deploys docs on tag.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,11 +121,11 @@ docstring-code-format = true
 python-version = "3.10"
 
 [tool.ty.src]
-include = ["typus/**/*.py"]
+include = ["typus/**/*.py", "tests/**/*.py", "scripts/**/*.py"]
 
 [tool.ty.terminal]
 output-format = "full"
-error-on-warning = false
+error-on-warning = true
 
 [tool.pytest.ini_options]
 addopts    = "-q"

--- a/skills/typus/SKILL.md
+++ b/skills/typus/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: typus
 description: "Typus repo knowledge for taxonomy primitives, canonical geometry, and integration-safe usage patterns. Use before modifying typus or consumers of taxonomy/geometry DTO contracts."
-version: "0.2.0"
+version: "0.3.0"
 x:
   source_repo: "typus"
   source_branch: "main"
   source_commit: "a5e6742"
   package_version: "0.5.0"
-  last_modified: "2026-03-02T00:00:00Z"
+  last_modified: "2026-03-13T18:35:00Z"
 ---
 
 # Typus
@@ -21,6 +21,9 @@ Use this skill before changing Typus internals or any integration that depends o
 - Public exports entrypoint: `typus/__init__.py`
 - Optional extras: `[postgres]`, `[sqlite]`, `[loader]`, `[pgvector]`, `[dev]`, `[docs]`
 - Core domains: taxonomy service contract, canonical geometry, track/classification DTOs
+- Canonical contributor docs: `docs/contributing.md`
+- Canonical bootstrap: `./dev/scripts/bootstrap-dev.sh`
+- Canonical local quality gate: `make check-all`
 
 ## Trigger Conditions
 
@@ -40,11 +43,9 @@ Use this skill when the task touches one or more of these:
    - bbox and geometry helpers: `references/geometry-utilities.md`
    - downstream usage and compatibility guardrails: `references/integration-patterns.md`
 3. Keep changes backwards compatible unless a breaking change is explicitly requested.
-4. Run repo gates before handoff:
-   - `make format`
-   - `make lint`
-   - `make typecheck`
-   - `make test`
+4. Use `docs/contributing.md` for contributor setup and gate policy instead of duplicating setup steps in task notes.
+5. Bootstrap or resync the local dev environment with `./dev/scripts/bootstrap-dev.sh` when needed.
+6. Run `make check-all` before handoff. Use focused commands like `make typecheck` or `make test` only for narrower loops during implementation.
 
 ## Guardrails
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,7 @@
+from typus.models.taxon import Taxon
+
+SearchTaxaResult = list[Taxon] | list[tuple[Taxon, float]]
+
+
+def taxon_ids(results: SearchTaxaResult) -> list[int]:
+    return [item[0].taxon_id if isinstance(item, tuple) else item.taxon_id for item in results]

--- a/tests/test_cross_backend_parity.py
+++ b/tests/test_cross_backend_parity.py
@@ -6,11 +6,9 @@ from typing import List
 import pytest
 from sqlalchemy.ext.asyncio import create_async_engine
 
+from tests.helpers import taxon_ids
 from tests.pg_test_utils import is_database_unavailable_error, resolve_test_dsn
-from typus.models.taxon import Taxon
 from typus.services import PostgresTaxonomyService, SQLiteTaxonomyService, load_expanded_taxa
-
-SearchTaxaResult = list[Taxon] | list[tuple[Taxon, float]]
 
 
 @dataclass
@@ -30,10 +28,6 @@ CASES: List[QueryCase] = [
     # Substring on binomial
     QueryCase("mellif", "scientific", "substring"),
 ]
-
-
-def taxon_ids(results: SearchTaxaResult) -> list[int]:
-    return [item[0].taxon_id if isinstance(item, tuple) else item.taxon_id for item in results]
 
 
 def sqlite_fixture_count() -> int:

--- a/tests/test_cross_backend_parity.py
+++ b/tests/test_cross_backend_parity.py
@@ -7,7 +7,10 @@ import pytest
 from sqlalchemy.ext.asyncio import create_async_engine
 
 from tests.pg_test_utils import is_database_unavailable_error, resolve_test_dsn
+from typus.models.taxon import Taxon
 from typus.services import PostgresTaxonomyService, SQLiteTaxonomyService, load_expanded_taxa
+
+SearchTaxaResult = list[Taxon] | list[tuple[Taxon, float]]
 
 
 @dataclass
@@ -27,6 +30,10 @@ CASES: List[QueryCase] = [
     # Substring on binomial
     QueryCase("mellif", "scientific", "substring"),
 ]
+
+
+def taxon_ids(results: SearchTaxaResult) -> list[int]:
+    return [item[0].taxon_id if isinstance(item, tuple) else item.taxon_id for item in results]
 
 
 def sqlite_fixture_count() -> int:
@@ -68,7 +75,7 @@ async def test_cross_backend_parity_seeded_queries():
             fuzzy=False,
             limit=100,
         )
-        baseline[(c.query, c.scope, c.match)] = [t.taxon_id for t in res]
+        baseline[(c.query, c.scope, c.match)] = taxon_ids(res)
 
     dsn = resolve_test_dsn()
     if not dsn:
@@ -100,7 +107,7 @@ async def test_cross_backend_parity_seeded_queries():
             if is_database_unavailable_error(e):
                 pytest.skip(f"Postgres database unavailable: {e}")
             raise
-        pg_ids = [t.taxon_id for t in res_pg]
+        pg_ids = taxon_ids(res_pg)
         base_ids = baseline[(c.query, c.scope, c.match)]
 
         if datasets_match:

--- a/tests/test_detection_serialise.py
+++ b/tests/test_detection_serialise.py
@@ -61,15 +61,15 @@ SAMPLE_INSTANCE_PREDICTION_NO_MASK_NO_CLASS = InstancePrediction(
     instance_id=2, bbox=SAMPLE_BBOX_CXCYWH_REL, score=0.88
 )
 
-SAMPLE_TAXONOMY_CONTEXT = TaxonomyContext(
-    taxonomy_id="test_taxonomy_v1", lca_graph_id="test_lca_graph_v1"
+SAMPLE_IMAGE_TAXONOMY_CONTEXT = TaxonomyContext(
+    source="test_taxonomy_v1", version="test_lca_graph_v1"
 )
 
 SAMPLE_IMAGE_DETECTION_RESULT = ImageDetectionResult(
     width=1000,
     height=800,
     instances=[SAMPLE_INSTANCE_PREDICTION_FULL, SAMPLE_INSTANCE_PREDICTION_NO_MASK_NO_CLASS],
-    taxonomy_context=SAMPLE_TAXONOMY_CONTEXT,
+    taxonomy_context=SAMPLE_IMAGE_TAXONOMY_CONTEXT,
 )
 
 # --- Test Cases ---

--- a/tests/test_models_canonical_bbox.py
+++ b/tests/test_models_canonical_bbox.py
@@ -78,6 +78,7 @@ class TestDetectionCanonicalBbox:
 
         detection = Detection.from_raw_detection(raw_data)
 
+        assert detection.bbox_norm is not None
         assert detection.bbox_norm.x == 0.1
         assert detection.bbox_norm.y == 0.2
         assert detection.bbox_norm.w == 0.3
@@ -249,4 +250,5 @@ class TestTrackWithCanonicalBbox:
 
         # Should deserialize successfully
         track_restored = Track.model_validate(track_dict)
+        assert track_restored.detections[0].bbox_norm is not None
         assert track_restored.detections[0].bbox_norm.x == 0.1

--- a/tests/test_name_search.py
+++ b/tests/test_name_search.py
@@ -2,16 +2,10 @@ import sqlite3
 
 import pytest
 
+from tests.helpers import taxon_ids
 from tests.pg_test_utils import is_database_unavailable_error, resolve_test_dsn
 from typus.constants import RankLevel
-from typus.models.taxon import Taxon
 from typus.services import SQLiteTaxonomyService
-
-SearchTaxaResult = list[Taxon] | list[tuple[Taxon, float]]
-
-
-def taxon_ids(results: SearchTaxaResult) -> list[int]:
-    return [item[0].taxon_id if isinstance(item, tuple) else item.taxon_id for item in results]
 
 
 @pytest.mark.asyncio
@@ -20,7 +14,7 @@ async def test_scientific_exact_name(taxonomy_service):
     res = await taxonomy_service.search_taxa(
         "Apis mellifera", scopes={"scientific"}, match="exact", fuzzy=False
     )
-    assert any(t.taxon_id == 47219 for t in res)
+    assert 47219 in taxon_ids(res)
 
 
 @pytest.mark.asyncio
@@ -33,7 +27,7 @@ async def test_scientific_prefix_and_rank_filter(taxonomy_service):
         fuzzy=False,
         rank_filter={RankLevel.L20},
     )
-    assert any(t.taxon_id == 47220 for t in res)
+    assert 47220 in taxon_ids(res)
 
 
 @pytest.mark.asyncio
@@ -42,7 +36,7 @@ async def test_vernacular_exact_name(taxonomy_service):
     res = await taxonomy_service.search_taxa(
         "honey bee", scopes={"vernacular"}, match="exact", fuzzy=False
     )
-    assert any(t.taxon_id == 47219 for t in res)
+    assert 47219 in taxon_ids(res)
 
 
 @pytest.mark.asyncio
@@ -56,7 +50,7 @@ async def test_vernacular_fuzzy_near_miss(taxonomy_service):
         threshold=0.7,
         limit=10,
     )
-    assert any(t.taxon_id == 47219 for t in res)
+    assert 47219 in taxon_ids(res)
 
 
 @pytest.mark.asyncio

--- a/tests/test_name_search.py
+++ b/tests/test_name_search.py
@@ -4,7 +4,14 @@ import pytest
 
 from tests.pg_test_utils import is_database_unavailable_error, resolve_test_dsn
 from typus.constants import RankLevel
+from typus.models.taxon import Taxon
 from typus.services import SQLiteTaxonomyService
+
+SearchTaxaResult = list[Taxon] | list[tuple[Taxon, float]]
+
+
+def taxon_ids(results: SearchTaxaResult) -> list[int]:
+    return [item[0].taxon_id if isinstance(item, tuple) else item.taxon_id for item in results]
 
 
 @pytest.mark.asyncio
@@ -107,7 +114,7 @@ async def test_sqlite_search_accepts_text_boolean_taxon_active(tmp_path):
     finally:
         svc.close()
 
-    assert [t.taxon_id for t in res] == [47219]
+    assert taxon_ids(res) == [47219]
 
 
 @pytest.mark.asyncio
@@ -127,4 +134,4 @@ async def test_postgres_parity_when_available():
         if is_database_unavailable_error(e):
             pytest.skip(f"Postgres database unavailable: {e}")
         raise
-    assert any(t.taxon_id == 47219 for t in res)
+    assert 47219 in taxon_ids(res)

--- a/tests/test_tracks.py
+++ b/tests/test_tracks.py
@@ -408,16 +408,24 @@ class TestTrack:
 
         # Invalid validation status
         with pytest.raises(ValidationError):
-            Track(
-                track_id="track_001",
-                clip_id="video_20240108",
-                detections=[Detection(frame_number=100, bbox=[10, 20, 50, 60], confidence=0.90)],
-                start_frame=100,
-                end_frame=100,
-                duration_frames=1,
-                duration_seconds=0.03,
-                confidence=0.90,
-                validation_status="invalid_status",  # Not in allowed values
+            Track.model_validate(
+                {
+                    "track_id": "track_001",
+                    "clip_id": "video_20240108",
+                    "detections": [
+                        {
+                            "frame_number": 100,
+                            "bbox": [10, 20, 50, 60],
+                            "confidence": 0.90,
+                        }
+                    ],
+                    "start_frame": 100,
+                    "end_frame": 100,
+                    "duration_frames": 1,
+                    "duration_seconds": 0.03,
+                    "confidence": 0.90,
+                    "validation_status": "invalid_status",
+                }
             )
 
     def test_track_json_serialization(self, sample_detections):
@@ -452,7 +460,7 @@ class TestTrack:
     def test_backward_compatibility(self):
         """Test that Track can handle legacy data formats."""
         # Simulate legacy format from distillation pipeline
-        legacy_data = {
+        legacy_data: dict[str, object] = {
             "track_id": "legacy_001",
             "clip_id": "video_legacy",
             "detections": [{"frame_number": 50, "bbox": [100, 200, 50, 60], "confidence": 0.85}],
@@ -464,7 +472,7 @@ class TestTrack:
         }
 
         # Should be able to create Track from legacy data
-        track = Track(**legacy_data)
+        track = Track.model_validate(legacy_data)
         assert track.track_id == "legacy_001"
         assert track.validation_status == "pending"  # Default value
         assert track.smoothing_applied is False  # Default value

--- a/typus/models/detection_utils/utils.py
+++ b/typus/models/detection_utils/utils.py
@@ -60,7 +60,7 @@ def to_coco(image: ImageDetectionResult, category_map: Dict[int, int]) -> Dict:
             # Should not happen if bbox.fmt is always one of the enum values
             raise ValueError(f"Unsupported bbox format: {instance.bbox.fmt}")
 
-        annotation = {
+        annotation: dict[str, object] = {
             "image_id": 0,  # Placeholder, COCO expects an image_id
             "category_id": coco_category_id,
             "bbox": [abs_x, abs_y, abs_w, abs_h],


### PR DESCRIPTION
## Summary
- harden the Typus `ty` contract by failing on warnings and expanding the checked surface to `tests/**/*.py` and `scripts/**/*.py`
- fix the runtime/test typing fallout and promote `make check-all` as the canonical local quality gate used by CI/publish
- add a tracked, idempotent `dev/scripts/bootstrap-dev.sh` and route contributor docs plus the Typus skill to canonical bootstrap/contributing docs

## Testing
- `./dev/scripts/bootstrap-dev.sh`
- `./dev/scripts/bootstrap-dev.sh` (rerun to verify idempotence)
- `make typecheck`
- `make check-all`
- repo pre-commit hooks on `git commit`
- repo pre-push hooks on `git push`

## Linear
- `POL-692`