### PR TITLE
POL-1277: Node 24 action upgrades + third-party SHA pinning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# Supply-chain posture (POL-1265 / POL-1277): keep GitHub Actions references
+# current -- including SHA-pinned third-party actions -- with the same 7-day
+# cooldown applied to package dependencies.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,18 +18,19 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           version: "0.10.12"
           enable-cache: true
+          ignore-nothing-to-cache: true
           cache-dependency-glob: |
             pyproject.toml
             uv.lock

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,10 +16,10 @@ jobs:
     name: Build & Deploy Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with: { python-version: '3.12' }
-      - uses: astral-sh/setup-uv@v3
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           version: "0.10.12"
           enable-cache: true
@@ -32,7 +32,7 @@ jobs:
       - name: Build docs
         run: uv run --locked --extra docs mkdocs build
       - name: Add SSH key
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         with:
           ssh-private-key: ${{ secrets.POLLISERVE0_SSH_PRIVATE_KEY }}
       - name: Check SSH connectivity
@@ -47,7 +47,7 @@ jobs:
             site/ ${{ secrets.POLLISERVE0_SSH_USER }}@${{ secrets.POLLISERVE0_SSH_PUBLIC_HOST }}:/var/www/docs.polli.ai/html/typus/
       - name: Upload built site as artifact on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: site
           path: site/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,16 +10,17 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
       - name: Set up uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           version: "0.10.12"
           enable-cache: true
+          ignore-nothing-to-cache: true
           cache-dependency-glob: |
             pyproject.toml
             uv.lock
@@ -39,18 +40,19 @@ jobs:
       contents: write  # needed to upload release asset
       id-token: write  # for OIDC (if you prefer it)
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           version: "0.10.12"
           enable-cache: true
+          ignore-nothing-to-cache: true
           cache-dependency-glob: |
             pyproject.toml
             uv.lock
@@ -79,7 +81,7 @@ jobs:
 
       - name: Upload wheel as GitHub release asset
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           files: dist/*
 
@@ -92,10 +94,10 @@ jobs:
       group: docs-deploy
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with: { python-version: '3.12' }
-      - uses: astral-sh/setup-uv@v3
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           version: "0.10.12"
           enable-cache: true
@@ -104,7 +106,7 @@ jobs:
             uv.lock
       - run: uv sync --locked --extra docs
       - run: uv run --locked --extra docs mkdocs build
-      - uses: webfactory/ssh-agent@v0.9.0
+      - uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         with:
           ssh-private-key: ${{ secrets.POLLISERVE0_SSH_PRIVATE_KEY }}
       - name: Check SSH connectivity


### PR DESCRIPTION
Public parity promotion of polli-labs/typus-dev#9 (org-wide POL-1277 pass; reference: polli-labs/polli#471).

GitHub forces node20-backed actions onto Node 24 on **2026-06-16**. Same change as the private repo: checkout v6, setup-python v6, upload-artifact v7, setup-uv SHA-pinned at v8.2.0 (+ `ignore-nothing-to-cache: true`), ssh-agent SHA-pinned at v0.10.0, gh-release SHA-pinned at v3.0.0, dependabot github-actions config (weekly, 7-day cooldown).

setup-uv input audit: only `version`/`enable-cache`/`cache-dependency-glob` in use — no v6-removed inputs, no venv-activation reliance.

`ci.yml` on this PR exercises the upgraded checkout/setup-python/setup-uv path; `publish.yml` (PyPI lane) runs at the next release tag.

Linear: POL-1277

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated dependency checks for build tools with scheduled weekly updates.
  * Updated build and deployment infrastructure to use latest compatible versions of automation tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->